### PR TITLE
fix(email): nodemailer и smtp вместо AWS SES класса

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,7 +39,10 @@ const lambdaConfig = {
   },
   emailService: {
     debug: false,
-    senderEmailAddress: process.env.SENDER_EMAIL_ADDRESS
+    senderEmailAddress: process.env.SENDER_EMAIL_ADDRESS,
+    smtpHost: process.env.SMTP_HOST,
+    smtpUser: process.env.SMTP_USER,
+    smtpPass: process.env.SMTP_PASS
   },
   aws: {
     region: process.env.AWS_REGION,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,6 +1285,15 @@
       "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
       "dev": true
     },
+    "@types/nodemailer": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.0.tgz",
+      "integrity": "sha512-KY7bFWB0MahRZvVW4CuW83qcCDny59pJJ0MQ5ifvfcjNwPlIT0vW4uARO4u1gtkYnWdhSvURegecY/tzcukJcA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -6387,6 +6396,11 @@
           }
         }
       }
+    },
+    "nodemailer": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.11.tgz",
+      "integrity": "sha512-BVZBDi+aJV4O38rxsUh164Dk1NCqgh6Cm0rQSb9SK/DHGll/DrCMnycVDD7msJgZCnmVa8ASo8EZzR7jsgTukQ=="
     },
     "nodemon": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint:fix": "[ \"$CI\" = true ] && eslint --quiet -f codeframe --ext js,ts . --fix || eslint --ext js,ts . --fix",
     "lint": "npm run eslint && npm run tsc",
     "tsc": "tsc -p .",
-    "clean": "rm tsconfig.tsbuildinfo && docker-compose -f ./docker-compose-dev.yml rm --force && rimraf app",
+    "clean": "rm -f tsconfig.tsbuildinfo && docker-compose -f ./docker-compose-dev.yml rm --force && rimraf app",
     "test": "npm run lint && jest --testPathPattern=test/",
     "test:ci": "node utils/wait-for.js core 8080 50000 && npm run test",
     "build": "tsc -p .",
@@ -29,14 +29,15 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/cors": "^2.8.7",
     "@types/busboy": "^0.2.3",
+    "@types/cors": "^2.8.7",
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.8",
     "@types/jest": "^26.0.13",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/knex": "^0.16.1",
     "@types/node": "^14.10.1",
+    "@types/nodemailer": "^6.4.0",
     "@types/rimraf": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
@@ -46,19 +47,20 @@
     "form-data": "^3.0.0",
     "jest": "^26.4.2",
     "nodemon": "^2.0.4",
+    "rimraf": "^3.0.2",
     "ts-jest": "^26.3.0",
-    "typescript": "^4.0.2",
-    "rimraf": "^3.0.2"
+    "typescript": "^4.0.2"
   },
   "dependencies": {
     "ajv": "^6.12.4",
-    "cors": "^2.8.5",
     "busboy": "^0.3.1",
+    "cors": "^2.8.5",
     "debug": "^4.1.1",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "knex": "^0.21.5",
     "knex-paginate": "^1.2.3",
+    "nodemailer": "^6.4.11",
     "pg": "^8.3.3"
   }
 }


### PR DESCRIPTION
В AWS lambda была обнаружена неприятная особенность - необходимый
email.eu-central-1.amazonaws.com endpoint не доступен, если лямбда
находится внутри VPC.

Интернет полон жалоб людей и различных вариантов решения:
- можно запустить еще одну лямбду вне VPC и научить их общаться -
  добавляет прилично сложности в нашем текущем окружении, добавляет
  рисков в области безопасности, не факт, что общение между лямбдами
  это что-то легко реализуемое.
- можно попробовать использовать vpc endpoints, фичу, которую с виду
  специально сделали, чтобы из vpc было видно нужные для API endpoints,
  но к сожалению как мы не вращали эту фичу, как не прикладывали ее,
  API endpoints видны с EC2 инстанса, но не с AWS lambda.
- можно использовать email-smtp endpoint и smtp протокол напрямую без
  красивой обертки, которую отдает AWS SES, это первый вариант,
  который заработал. [1]

В целом вариант с smtp и nodemailer обладает еще одним плюсом - он
уменьшает нашу зависимость от AWS.

nodemailer крайне старая node библиотека без зависимостей, покрытая
тестами и со всего 4 открытыми минорными багами против 1200 уже починенных.

[1] https://stackoverflow.com/questions/43293966/not-able-to-send-email-from-lambda-to-ses-from-within-a-vpc