### PR TITLE
feat: X-Request-Id header вместо RqUid

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tsc": "tsc -p .",
     "clean": "rm -f tsconfig.tsbuildinfo && docker-compose -f ./docker-compose-dev.yml rm --force && rimraf app",
     "test": "npm run lint && npm run test:api",
-    "test:api": "jest --testPathPattern=test/",
+    "test:api": "jest -i --testPathPattern=test/",
     "test:ci": "node utils/wait-for.js core 8080 50000 && npm run test",
     "build": "tsc -p .",
     "prestart": "npm run build",

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,7 @@
 import express from 'express';
 
 import validator from './validator';
-import {TestController, TestEntryController} from './controllers/testController';
+import {TestController, TestEntryController, TestSuccessRouter} from './controllers/testController';
 import {ProfileController} from './controllers/profileController';
 import {AuthMagicLinkController, RefreshTokenController} from './controllers/authController';
 import {EmailMagicLinkSenderController} from './controllers/emailSenderController';
@@ -28,6 +28,7 @@ import {SingleContactController, AllContactsController} from './controllers/cont
 
 import { errorHandler, notFoundHandler } from './errorHandler';
 import {accessTokenHandler} from './accessTokenHandler';
+import requestIdHandler from './requestId';
 import cors from 'cors';
 import {UserController, UsersController} from './controllers/usersController';
 const app = express();
@@ -35,6 +36,7 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({extended: false}));
+app.use(requestIdHandler);
 
 // all API endpoints are listed below this line.
 function register(app: express.Express, endpoint: string, router: express.Router, authRequired?: boolean) {
@@ -43,6 +45,8 @@ function register(app: express.Express, endpoint: string, router: express.Router
 
 register(app, '/v1/test/:id', TestEntryController);
 register(app, '/v1/test/', TestController);
+register(app, '/test/success', TestSuccessRouter);
+
 register(app, '/v1/auth/magicLink', AuthMagicLinkController);
 register(app, '/v1/auth/refresh', RefreshTokenController);
 register(app, '/v1/email/sendMagicLink', EmailMagicLinkSenderController);

--- a/src/controllers/contactController.ts
+++ b/src/controllers/contactController.ts
@@ -28,43 +28,41 @@ interface ContactValue {
 const singleContactRouter = express.Router();
 singleContactRouter.route('/')
     .put(async (request, response) => {
-      const {RqUid, contactId, title, url} = getArgs(request);
+      const {contactId, title, url} = getArgs(request);
       const {id: currentUserId} = request.user!;
       try {
         const count = await Contact().where('ownerId', currentUserId).andWhere('id', contactId).update({title, url}).count();
         if (count > 0)
-          return response.status(200).json({RqUid}).end();
+          return response.status(200).json({}).end();
         else
-          return response.status(404).json({RqUid}).end();
+          return response.status(404).json({}).end();
       } catch (e) {
         const UNIQUE_VIOLATION_CODE = '23505';
         if (e.code === UNIQUE_VIOLATION_CODE)
-          return response.status(422).json({RqUid}).end();
+          return response.status(422).json({}).end();
         console.debug('PUT contact/:id', e);
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     })
     .delete(async (request, response) => {
-      const {RqUid, contactId} = getArgs(request);
+      const {contactId} = getArgs(request);
       const {id: currentUserId} = request.user!;
       try {
         await Contact().where('id', contactId).andWhere('ownerId', currentUserId).del();
-        return response.status(200).json({RqUid}).end();
+        return response.status(200).json({}).end();
       } catch (e) {
         console.debug('DELETE contact/:id', e);
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     });
 
 const allContactsRouter = express.Router();
 allContactsRouter.route('/')
     .get(async (request, response) => {
-      const {RqUid} = getArgs(request);
       const {id: currentUserId} = request.user!;
       try {
         const contacts = await Contact().where('ownerId', currentUserId).orderBy('title', 'asc').select();
         response.status(200).json({
-          RqUid,
           contacts: contacts.map((entry: ContactValue) => ({
             id: entry.id,
             title: entry.title,
@@ -73,20 +71,20 @@ allContactsRouter.route('/')
         });
       } catch (e) {
         console.debug('GET contact/', e);
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     })
     .post(async (request, response) => {
-      const {RqUid, title, url} = getArgs(request);
+      const {title, url} = getArgs(request);
       const {id: currentUserId} = request.user!;
       try {
         const [contactId] = await Contact().returning('id').insert({title, url, ownerId: currentUserId});
         if (contactId)
-          return response.status(200).json({RqUid, contactId}).end();
-        return response.status(500).json({RqUid}).end();
+          return response.status(200).json({contactId}).end();
+        return response.status(500).json({}).end();
       } catch (e) {
         console.debug('POST contact/', e);
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     });
 

--- a/src/controllers/emailSenderController.ts
+++ b/src/controllers/emailSenderController.ts
@@ -37,7 +37,7 @@ const UserTokenEntries = () => knex('UserToken');
 const emailMagicLinkSenderRouter = express.Router();
 emailMagicLinkSenderRouter.route('/')
     .post(async (request, response) => {
-      const {email, tokenId, RqUid} = getArgs(request);
+      const {email, tokenId} = getArgs(request);
 
       try {
         const user = await UserEntries().where('email', email).andWhere('status', UserStatus.APPROVED).first();
@@ -49,21 +49,21 @@ emailMagicLinkSenderRouter.route('/')
           if (userToken) {
             return jsonwebtoken.verify(userToken.token, refreshJwtSecret,{algorithms: ['HS256']}, async (err: VerifyErrors | null) => {
               if (err)
-                return response.status(404).json({RqUid}).end();
+                return response.status(404).json({}).end();
 
               const magicLink = `${magicLinkUrl}token=${userToken.token}`;
               await emailService.sendMagicLinkEmail(email, fullName, magicLink);
-              return response.status(200).json({RqUid}).end();
+              return response.status(200).json({}).end();
             });
           }
 
-          return response.status(404).json({RqUid}).end();
+          return response.status(404).json({}).end();
         }
 
-        response.status(404).json({RqUid}).end();
+        response.status(404).json({}).end();
       } catch (e) {
         console.debug('email/sendMagicLink error', e);
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     });
 

--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -25,46 +25,46 @@ const FriendEntries = () => knex('Friend');
 const friendEntryRouter = express.Router();
 friendEntryRouter.route('/')
     .post(async (request, response) => {
-      const {friendId, RqUid} = getArgs(request);
+      const {friendId} = getArgs(request);
       const {id: userId} = request.user!;
 
       if (friendId === userId)
-        return response.status(400).json({RqUid, message: 'You cannot add yourself as a friend'}).end();
+        return response.status(400).json({message: 'You cannot add yourself as a friend'}).end();
 
       try {
         const friend = await UserEntries().where('id', friendId).first('status');
 
         if (!friend || friend.status !== UserStatus.APPROVED)
-          return response.status(404).json({RqUid}).end();
+          return response.status(404).json({}).end();
 
         const [id] = await FriendEntries().returning('id').insert({friendId, userId});
 
         if (id)
-          return response.status(201).json({RqUid}).end();
+          return response.status(201).json({}).end();
 
-        return response.status(500).json({RqUid}).end();
+        return response.status(500).json({}).end();
       } catch (e) {
         console.debug('POST user/friend/:friendId error', e);
 
         if (e.code === '23505')
-          return response.status(209).json({RqUid}).end();
+          return response.status(209).json({}).end();
 
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     })
     .delete(async (request, response) => {
-      const {friendId, RqUid} = getArgs(request);
+      const {friendId} = getArgs(request);
       const {id: userId} = request.user!;
       try {
         const count = await FriendEntries().where('userId', userId).andWhere('friendId', friendId).del();
 
         if (count)
-          return response.status(200).json({RqUid}).end();
+          return response.status(200).json({}).end();
 
-        return response.status(209).json({RqUid}).end();
+        return response.status(209).json({}).end();
       } catch (e) {
         console.debug('DELETE user/friend/:friendId error', e);
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     });
 

--- a/src/controllers/locationController.ts
+++ b/src/controllers/locationController.ts
@@ -30,7 +30,7 @@ const router = express.Router();
 
 router.route('/')
     .post(async (request, response) => {
-      const { RqUid, userInput } = getArgs(request);
+      const { userInput } = getArgs(request);
       try {
         const location = await knex.select('c.name as cityName','co.name as countryName')
             .from('City AS c')
@@ -38,9 +38,9 @@ router.route('/')
             .leftJoin('Country AS co', 'r.country_id', 'co.id')
             .where('c.name', 'like', `%${userInput}%`)
             .limit(5);
-        response.status(200).json({ location: location.map((e: any) => ({city: e.cityName, country: e.countryName})), RqUid }).end();
+        response.status(200).json({ location: location.map((e: any) => ({city: e.cityName, country: e.countryName})) }).end();
       } catch (error) {
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     });
 export { router as LocationsController };

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -26,7 +26,7 @@ const UserEntries = () => knex('User');
 const router = express.Router();
 router.route('/')
     .post(async (request, response) => {
-      const {RqUid, query, currentPage, perPage, onlyFriends} = getArgs(request);
+      const {query, currentPage, perPage, onlyFriends} = getArgs(request);
       const {id: userId} = request.user!;
       try {
         const fields = [ 'User.id', 'fullName', 'username', 'imagePath', 'location', 'about', 'role', 'skills', 'status'];
@@ -55,10 +55,10 @@ router.route('/')
 
         // TODO(ak239spb): nice way to handle database errors.
 
-        response.status(200).json({RqUid, entries}).end();
+        response.status(200).json({entries}).end();
       } catch (e) {
         console.debug('POST profile/search error', e);
-        response.status(500).json({RqUid}).end();
+        response.status(500).json({}).end();
       }
     });
 

--- a/src/controllers/testController.ts
+++ b/src/controllers/testController.ts
@@ -31,38 +31,37 @@ const TestEntries = () => knex('test_entries');
 const entryRouter = express.Router();
 entryRouter.route('/')
     .get(async (request, response) => {
-      const {id, RqUid} = getArgs(request);
+      const {id} = getArgs(request);
       const entry = await TestEntries().where('id', id).first();
       if (entry)
-        response.status(200).json({...entry, RqUid}).end();
+        response.status(200).json({...entry}).end();
       else
-        response.status(404).json({RqUid}).end();
+        response.status(404).json({}).end();
     })
     .put(async (request, response) => {
-      const {id, RqUid, fieldA, fieldB} = getArgs(request);
+      const {id, fieldA, fieldB} = getArgs(request);
       await TestEntries().where('id', id).update({fieldA, fieldB});
-      response.status(200).send({RqUid}).end();
+      response.status(200).send({}).end();
     })
     .delete(async (request, response) => {
-      const {id, RqUid} = getArgs(request);
+      const {id} = getArgs(request);
       await TestEntries().where('id', id).del();
-      response.status(200).send({RqUid}).end();
+      response.status(200).send({}).end();
     });
 
 const router = express.Router();
 router.route('/')
     .get(async (request, response) => {
-      const {RqUid} = getArgs(request);
       // TODO(ak239spb): how will we do pagination.
       // TODO(ak239spb): nice way to handle database errors.
-      response.status(200).json({RqUid, entries: await TestEntries().select()}).end();
+      response.status(200).json({entries: await TestEntries().select()}).end();
     })
     .post(async (request, response, next) => {
-      const {RqUid, fieldA, fieldB} = getArgs(request);
+      const {fieldA, fieldB} = getArgs(request);
       try {
         const [id] = await TestEntries().returning('id').insert({fieldA, fieldB});
         if (id)
-          response.status(200).json({id, RqUid}).end();
+          response.status(200).json({id}).end();
         else
           response.status(500).json({}).end();
       } catch (e) {
@@ -70,4 +69,11 @@ router.route('/')
       }
     });
 
-export { entryRouter as TestEntryController, router as TestController };
+const successRouter = express.Router();
+successRouter.route('/')
+    .get(async (request, response) => response.status(200).json({}).end())
+    .post(async (request, response) => response.status(200).json({}).end())
+    .put(async (request, response) => response.status(200).json({}).end())
+    .delete(async (request, response) => response.status(200).json({}).end());
+
+export { entryRouter as TestEntryController, router as TestController, successRouter as TestSuccessRouter };

--- a/src/controllers/uploadImageController.ts
+++ b/src/controllers/uploadImageController.ts
@@ -16,7 +16,6 @@
 
 import express from 'express';
 import { S3 } from 'aws-sdk';
-import {getArgs} from '../utils';
 import Busboy from 'busboy';
 const config = require('../../config.js');
 
@@ -46,8 +45,6 @@ async function uploadFileToS3(content: Buffer, mimeType: string) {
 const uploadRouter = express.Router();
 uploadRouter.route('/')
     .post(async (request, response) => {
-      const {RqUid} = getArgs(request);
-
       const busboy = new Busboy({
         headers: request.headers,
         limits: {
@@ -80,16 +77,16 @@ uploadRouter.route('/')
         file.on('end', async () => {
           try {
             if (errorCode > 0)
-              return response.status(500).json({RqUid, errorMessage, errorCode}).end();
+              return response.status(500).json({errorMessage, errorCode}).end();
 
             const content = Buffer.concat(temp);
             const path = await uploadFileToS3(content, mimetype);
 
             const url = `https://${config.imageUpload.bucketName}.s3.amazonaws.com/` + path;
-            return response.status(200).json({RqUid, path: path, url: url }).end();
+            return response.status(200).json({path: path, url: url }).end();
           } catch (e) {
             console.error('uploadImage error', e);
-            return response.status(500).json({RqUid}).end();
+            return response.status(500).json({}).end();
           }
         });
       });

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -36,8 +36,6 @@ const ContactEntries = () => knex('Contact');
 const FriendEntries = () => knex('Friend');
 
 const handleUserRequestById = async (id: string, selfInfo: boolean, request: any, response: any) => {
-  const {RqUid} = getArgs(request);
-
   try {
     const contactsPromise = ContactEntries()
         .select([
@@ -76,9 +74,9 @@ const handleUserRequestById = async (id: string, selfInfo: boolean, request: any
     const [contacts, user, isFriend] = (await Promise.allSettled([contactsPromise, userPromise, isFriendPromise])).map(result => result.status === 'fulfilled' ? result.value : null);
 
     if (!user)
-      return response.status(404).json({RqUid}).end();
+      return response.status(404).json({}).end();
     if (!contacts)
-      return response.status(500).json({RqUid}).end();
+      return response.status(500).json({}).end();
 
     const result = {
       isFriend: !!isFriend,
@@ -86,10 +84,10 @@ const handleUserRequestById = async (id: string, selfInfo: boolean, request: any
       ...user
     };
 
-    response.status(200).json({RqUid, user: result}).end();
+    response.status(200).json({user: result}).end();
   } catch (e) {
     console.debug('handleUserRequestById error', e);
-    response.status(500).json({RqUid}).end();
+    response.status(500).json({}).end();
   }
 };
 
@@ -106,7 +104,7 @@ userController.route('/')
       await handleUserRequestById(request.user!.id!, true, request, response);
     })
     .put(async (request, response) => {
-      const { RqUid, location, role = null, about, fullName, skills = null, imagePath } = getArgs(request);
+      const { location, role = null, about, fullName, skills = null, imagePath } = getArgs(request);
       if (request.user) {
         try {
           const id = request.user.id;
@@ -118,13 +116,13 @@ userController.route('/')
             skills: skills,
             imagePath: imagePath
           });
-          response.status(200).send({ RqUid }).end();
+          response.status(200).json({}).end();
         } catch (error) {
           console.log(error);
-          response.status(500).send(RqUid).end();
+          response.status(500).json({}).end();
         }
       } else {
-        response.status(401).send(RqUid).end();
+        response.status(401).json({}).end();
       }
     });
 

--- a/src/requestId.ts
+++ b/src/requestId.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+
+export const HEADER_NAME = 'X-Request-Id';
+
+export default function(request: express.Request, response: express.Response, next: express.NextFunction) {
+  const headerValue = request.header(HEADER_NAME);
+  if (headerValue)
+    response.setHeader(HEADER_NAME, headerValue);
+  next();
+}

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -26,6 +26,22 @@
         "required": [ "id" ]
     },
     {
+      "$id": "#GET>/test/success",
+      "allOf": [{ "$ref": "#RequestBase" }],
+    },
+    {
+      "$id": "#POST>/test/success",
+      "allOf": [{ "$ref": "#RequestBase" }],
+    },
+    {
+      "$id": "#PUT>/test/success",
+      "allOf": [{ "$ref": "#RequestBase" }],
+    },
+    {
+      "$id": "#DELETE>/test/success",
+      "allOf": [{ "$ref": "#RequestBase" }],
+    },
+    {
         "$id": "#GET>/v1/test/",
         "allOf": [{ "$ref": "#RequestBase" }],
         "properties": {}

--- a/src/schema/base.json
+++ b/src/schema/base.json
@@ -3,8 +3,8 @@
         "$id": "#RequestBase",
         "type": "object",
         "properties": {
-            "RqUid": { "type": "string", "format": "uuid" }
+            "X-Request-Id": { "type": "string", "format": "uuid" }
         },
-        "required": [ "RqUid" ]
+        "required": [ "X-Request-Id" ]
     }
 ]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 import express from 'express';
+import {HEADER_NAME} from './requestId';
 
 const argsSymbol = Symbol('args');
 function getArgs(request: express.Request): any {
   if (typeof request === 'object') {
     const requestObject = request as any;
-    if (!requestObject[argsSymbol])
-      requestObject[argsSymbol] = Object.assign({}, request.body, request.params, request.query);
+    if (!requestObject[argsSymbol]) {
+      const args = Object.assign({}, request.body, request.params, request.query, {[HEADER_NAME]: request.header(HEADER_NAME)});
+      // TODO(ak239spb): code below is for compatibility only, remove it as soon as frontend ready for X-Request-Id header
+      if (!args[HEADER_NAME])
+        args[HEADER_NAME] = args.RqUid || args[HEADER_NAME];
+
+      requestObject[argsSymbol] = args;
+    }
     return requestObject[argsSymbol];
   }
   return {};

--- a/test/requestId.spec.js
+++ b/test/requestId.spec.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {get, post, put, del, getHost} = require('./utils.js');
+
+const ENDPOINT = `${getHost()}/test/success/`;
+
+test('X-Request-Id', async () => {
+  const headers = {'X-Request-Id': 'd5ab3356-f4b4-11ea-adc1-0242ac120002'};
+  const {code: getCode, headers: getHeaders} = await get(ENDPOINT, headers);
+  expect(getCode).toBe(200);
+  expect(getHeaders['x-request-id']).toBe(headers['X-Request-Id']);
+  const {code: postCode, headers: postHeaders} = await post(ENDPOINT, '', headers);
+  expect(postCode).toBe(200);
+  expect(postHeaders['x-request-id']).toBe(headers['X-Request-Id']);
+  const {code: putCode, headers: putHeaders} = await put(ENDPOINT, '', headers);
+  expect(putCode).toBe(200);
+  expect(putHeaders['x-request-id']).toBe(headers['X-Request-Id']);
+  const {code: delCode, headers: delHeaders} = await del(ENDPOINT, headers);
+  expect(delCode).toBe(200);
+  expect(delHeaders['x-request-id']).toBe(headers['X-Request-Id']);
+});
+
+test('X-Request-Id wrong format', async () => {
+  const headers = {'X-Request-Id': '239'};
+  const {code: getCode} = await get(ENDPOINT, headers);
+  expect(getCode).toBe(400);
+  const {code: postCode} = await post(ENDPOINT, '', headers);
+  expect(postCode).toBe(400);
+  const {code: putCode} = await put(ENDPOINT, '', headers);
+  expect(putCode).toBe(400);
+  const {code: delCode} = await del(ENDPOINT, headers);
+  expect(delCode).toBe(400);
+});
+
+test('without X-Request-Id', async () => {
+  const {code: getCode} = await get(ENDPOINT, {});
+  expect(getCode).toBe(400);
+  const {code: postCode} = await post(ENDPOINT, '', {});
+  expect(postCode).toBe(400);
+  const {code: putCode} = await put(ENDPOINT, '', {});
+  expect(putCode).toBe(400);
+  const {code: delCode} = await del(ENDPOINT, {});
+  expect(delCode).toBe(400);
+});
+
+test('compatibility: RqUid instead of X-Request-Id', async () => {
+  const RqUid = 'd5ab3356-f4b4-11ea-adc1-0242ac120002';
+  const {code: getCode} = await get(ENDPOINT + '?RqUid=' + RqUid, {});
+  expect(getCode).toBe(200);
+  const {code: postCode} = await post(ENDPOINT, JSON.stringify({RqUid}), {});
+  expect(postCode).toBe(200);
+  const {code: putCode} = await put(ENDPOINT, JSON.stringify({RqUid}), {});
+  expect(putCode).toBe(200);
+  const {code: delCode} = await del(ENDPOINT + '?RqUid=' + RqUid, {});
+  expect(delCode).toBe(200);
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -25,17 +25,17 @@ const {
   }
 } = require('../config.js');
 
-function fetch(url, method, body, header = {}) {
+function fetch(url, method, body, header = {'X-Request-Id': 'd5ab3356-f4b4-11ea-adc1-0242ac120002'}) {
   debug('<', url, method, body, header);
   let requestFinished;
   const requestPromise = new Promise(resolve => requestFinished = resolve);
-  const req = (url.startsWith('https:') ? https : http).request(url, { method: method, headers: { 'Content-Type': 'application/json', ...header } }, res => {
+  const req = (url.startsWith('https:') ? https : http).request(url, { method: method, headers: { 'Content-Type': 'application/json', ...header} }, res => {
     res.setEncoding('utf8');
     let data = '';
     res.on('data', chunk => data += chunk);
     res.on('end', () => {
       debug('>', data, res.statusCode);
-      requestFinished({data: data ? JSON.parse(data) : {}, code: res.statusCode});
+      requestFinished({data: data ? JSON.parse(data) : {}, code: res.statusCode, headers: res.headers});
     });
   });
   if (body)
@@ -60,18 +60,15 @@ function del(url, header) {
   return fetch(url, 'DELETE', null, header);
 }
 
-function getRqUid() {
-  return 'd5ab3356-f4b4-11ea-adc1-0242ac120002';
-}
-
 function getHost() {
   return process.env.TEST_API_HOST || 'http://localhost:8080';
 }
 
 function getAuthHeader(user, jwtAlgorithm = 'HS256') {
   return {
-    Authorization: `Bearer ${jsonwebtoken.sign(user, accessJwtSecret, {expiresIn: accessJwtExpiresIn, algorithm: jwtAlgorithm})}`
+    Authorization: `Bearer ${jsonwebtoken.sign(user, accessJwtSecret, {expiresIn: accessJwtExpiresIn, algorithm: jwtAlgorithm})}`,
+    ['X-Request-Id']: 'd5ab3356-f4b4-11ea-adc1-0242ac120002'
   };
 }
 
-module.exports = { get, post, put, del, getRqUid, getHost, getAuthHeader };
+module.exports = { get, post, put, del, getHost, getAuthHeader };

--- a/test/v1/auth/authMagicLinkController.spec.js
+++ b/test/v1/auth/authMagicLinkController.spec.js
@@ -13,35 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { post, getHost, getRqUid } = require('../../utils.js');
+const { post, getHost } = require('../../utils.js');
 
 const ENDPOINT = `${getHost()}/v1/auth/magicLink`;
-const RqUid = getRqUid();
 
 test('/v1/auth/magicLink', async () => {
   const email = 'iryabinin@gmail.com';
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, email}));
+  const {code} = await post(ENDPOINT, JSON.stringify({email}));
   expect(code).toBe(200);
-  expect(data.RqUid).toEqual(RqUid);
 });
 
 test('/v1/auth/magicLink POST without email', async () => {
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid}));
+  const {data, code} = await post(ENDPOINT, JSON.stringify({}));
   expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
   expect(data.message).toBeDefined();
 });
 
 test('/v1/auth/magicLink POST incorrect format email', async () => {
   const email = 'incorrect format';
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, email}));
-  expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
-  expect(data.message).toBeDefined();
-});
-
-test('/v1/auth/magicLink POST without RqUid', async () => {
-  const email = 'iryabinin@gmail.com';
   const {data, code} = await post(ENDPOINT, JSON.stringify({email}));
   expect(code).toBe(400);
   expect(data.message).toBeDefined();
@@ -49,9 +38,8 @@ test('/v1/auth/magicLink POST without RqUid', async () => {
 
 test('/v1/auth/magicLink POST non-existent email', async () => {
   const email = 'non.existent@gmail.com';
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, email}));
+  const {code} = await post(ENDPOINT, JSON.stringify({email}));
   expect(code).toBe(404);
-  expect(data.RqUid).toEqual(RqUid);
 });
 
 test('/v1/auth/magicLink POST non-approved users', async () => {
@@ -62,8 +50,7 @@ test('/v1/auth/magicLink POST non-approved users', async () => {
   ];
 
   await Promise.all(emails.map(async email => {
-    const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, email}));
+    const {code} = await post(ENDPOINT, JSON.stringify({email}));
     expect(code).toBe(404);
-    expect(data.RqUid).toEqual(RqUid);
   }));
 });

--- a/test/v1/auth/refreshTokenController.spec.js
+++ b/test/v1/auth/refreshTokenController.spec.js
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { post, getHost, getRqUid } = require('../../utils.js');
+const { post, getHost } = require('../../utils.js');
 
 const ENDPOINT = `${getHost()}/v1/auth/refresh`;
-const RqUid = getRqUid();
 const fs = require('fs').promises;
 const url = require('url');
 
@@ -30,52 +29,38 @@ const {
 
 test('/v1/auth/refresh', async () => {
   const email = 'iryabinin@gmail.com';
-  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({RqUid, email}));
-  await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({RqUid, email, tokenId}));
+  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({email}));
+  await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({email, tokenId}));
 
   const magicLink = await fs.readFile(saveFilePath, 'utf8');
   const magicLinkToken = new URLSearchParams(url.parse(magicLink).query).get('token');
-  const {data: getTokenByMagicLinkData, code: getTokenByMagicLinkCode} = await post(ENDPOINT, JSON.stringify({RqUid, refreshToken: magicLinkToken}));
+  const {data: getTokenByMagicLinkData, code: getTokenByMagicLinkCode} = await post(ENDPOINT, JSON.stringify({refreshToken: magicLinkToken}));
 
   expect(getTokenByMagicLinkCode).toBe(200);
-  expect(getTokenByMagicLinkData.RqUid).toEqual(RqUid);
   expect(getTokenByMagicLinkData.refreshToken).toBeDefined();
   expect(getTokenByMagicLinkData.accessToken).toBeDefined();
 
-  const {data: getTokenByRefreshData, code: getTokenByRefreshCode} = await post(ENDPOINT, JSON.stringify({RqUid, refreshToken: getTokenByMagicLinkData.refreshToken}));
+  const {data: getTokenByRefreshData, code: getTokenByRefreshCode} = await post(ENDPOINT, JSON.stringify({refreshToken: getTokenByMagicLinkData.refreshToken}));
 
   expect(getTokenByRefreshCode).toBe(200);
-  expect(getTokenByRefreshData.RqUid).toEqual(RqUid);
   expect(getTokenByRefreshData.refreshToken).toBeDefined();
   expect(getTokenByRefreshData.accessToken).toBeDefined();
 
-  const {data: getTokenByUsedMagicLinkTokenData, code: getTokenByUsedMagicLinkTokenCode} = await post(ENDPOINT, JSON.stringify({RqUid, refreshToken: magicLinkToken}));
+  const {data: getTokenByUsedMagicLinkTokenData, code: getTokenByUsedMagicLinkTokenCode} = await post(ENDPOINT, JSON.stringify({refreshToken: magicLinkToken}));
 
   expect(getTokenByUsedMagicLinkTokenCode).toBe(401);
-  expect(getTokenByUsedMagicLinkTokenData.RqUid).toEqual(RqUid);
   expect(getTokenByUsedMagicLinkTokenData.refreshToken).toBeUndefined();
   expect(getTokenByUsedMagicLinkTokenData.accessToken).toBeUndefined();
 
-  const {data: getTokenByUsedRefreshTokenData, code: getTokenByUsedRefreshTokenCode} = await post(ENDPOINT, JSON.stringify({RqUid, refreshToken: getTokenByMagicLinkData.refreshToken}));
+  const {data: getTokenByUsedRefreshTokenData, code: getTokenByUsedRefreshTokenCode} = await post(ENDPOINT, JSON.stringify({refreshToken: getTokenByMagicLinkData.refreshToken}));
 
   expect(getTokenByUsedRefreshTokenCode).toBe(401);
-  expect(getTokenByUsedRefreshTokenData.RqUid).toEqual(RqUid);
   expect(getTokenByUsedRefreshTokenData.refreshToken).toBeUndefined();
   expect(getTokenByUsedRefreshTokenData.accessToken).toBeUndefined();
 });
 
 test('/v1/auth/refresh without refresh token', async () => {
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid}));
-
-  expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
-  expect(data.message).toBeDefined();
-});
-
-test('/v1/auth/refresh without RqUid', async () => {
-  const refreshToken = 'refreshToken';
-
-  const {data, code} = await post(ENDPOINT, JSON.stringify({refreshToken}));
+  const {data, code} = await post(ENDPOINT, JSON.stringify({}));
 
   expect(code).toBe(400);
   expect(data.message).toBeDefined();

--- a/test/v1/contact/contactController.spec.js
+++ b/test/v1/contact/contactController.spec.js
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
-const { get, post, put, del, getHost, getRqUid, getAuthHeader } = require('../../utils.js');
+const { get, post, put, del, getHost, getAuthHeader } = require('../../utils.js');
 
 const CONTACT_ENDPOINT = `${getHost()}/v1/contact/`;
-const RqUid = getRqUid();
-const RqUidQueryParam = '?RqUid=' + RqUid;
 const header = getAuthHeader({
   id: '00000000-1111-2222-3333-000000000001',
   fullName: 'Иван Рябинин',
 });
 
 async function checkCurrentContacts(expected) {
-  const {code: getAllCode, data: getAllData} = await get(CONTACT_ENDPOINT + RqUidQueryParam, header);
+  const {code: getAllCode, data: getAllData} = await get(CONTACT_ENDPOINT, header);
   expect(getAllCode).toBe(200);
-  expect(getAllData.RqUid).toBe(RqUid);
   expect(getAllData.contacts.length).toBe(expected.length);
   const compareContacts = (a,b) => a.title === b.title ? 0 : a.title > b.title ? 1 : -1;
   getAllData.contacts.sort(compareContacts);
@@ -58,25 +55,22 @@ test('/v1/contact', async () => {
     title: 'ZNetwork',
     url: 'http://mynextbigsocialnetwork/abc'
   };
-  const {code: newContactCode, data: newContactData} = await post(CONTACT_ENDPOINT + RqUidQueryParam, JSON.stringify(newContactDataExpected), header);
+  const {code: newContactCode, data: newContactData} = await post(CONTACT_ENDPOINT, JSON.stringify(newContactDataExpected), header);
   expect(newContactCode).toBe(200);
-  expect(newContactData.RqUid).toBe(RqUid);
   expect(newContactData.contactId).toBeDefined();
 
   await checkCurrentContacts([...getAllExpected, newContactDataExpected]);
 
   // check that we can edit contact
   const updatedNewContactExpected = {title: 'Zmytitle', url: 'http://myurl'};
-  const {code: updateContactCode, data: updateContactData} = await put(CONTACT_ENDPOINT + newContactData.contactId + RqUidQueryParam, JSON.stringify(updatedNewContactExpected), header);
+  const {code: updateContactCode} = await put(CONTACT_ENDPOINT + newContactData.contactId, JSON.stringify(updatedNewContactExpected), header);
   expect(updateContactCode).toBe(200);
-  expect(updateContactData.RqUid).toBe(RqUid);
 
   await checkCurrentContacts([...getAllExpected, updatedNewContactExpected]);
 
   // check that we can delete contact
-  const {code: deleteContactCode, data: deleteContactData } = await del(CONTACT_ENDPOINT + newContactData.contactId + RqUidQueryParam, header);
+  const {code: deleteContactCode} = await del(CONTACT_ENDPOINT + newContactData.contactId, header);
   expect(deleteContactCode).toBe(200);
-  expect(deleteContactData.RqUid).toBe(RqUid);
   await checkCurrentContacts(getAllExpected);
 });
 
@@ -97,9 +91,8 @@ test('/v1/contact bad new contact', async () => {
   await check({title: 'abc', url: 'http://myurl/' + 'x'.repeat(1024)});
 
   async function check(badContractData) {
-    const {code: newContactCode, data: newContactData} = await post(CONTACT_ENDPOINT + RqUidQueryParam, JSON.stringify(badContractData), header);
+    const {code: newContactCode} = await post(CONTACT_ENDPOINT, JSON.stringify(badContractData), header);
     expect(newContactCode).toBe(400);
-    expect(newContactData.RqUid).toBe(RqUid);
     await checkCurrentContacts(getAllExpected);
   }
 });
@@ -107,7 +100,7 @@ test('/v1/contact bad new contact', async () => {
 test('/v1/contact bad updated contact', async () => {
   await checkCurrentContacts(getAllExpected);
   const testContact = {title: 'Ztest', url: 'http://example.com'};
-  const {data: {contactId}} = await post(CONTACT_ENDPOINT + RqUidQueryParam, JSON.stringify(testContact), header);
+  const {data: {contactId}} = await post(CONTACT_ENDPOINT, JSON.stringify(testContact), header);
 
   // contactId is not uuid
   await check('0', {title: 'test', url: 'http://example.com'}, 400);
@@ -120,13 +113,12 @@ test('/v1/contact bad updated contact', async () => {
   // existing title + url
   await check(contactId, getAllExpected[0], 422);
 
-  await del(CONTACT_ENDPOINT + contactId + RqUidQueryParam, header);
+  await del(CONTACT_ENDPOINT + contactId, header);
   await checkCurrentContacts(getAllExpected);
 
   async function check(contactId, data, expectedCode) {
-    const {code: updateContactCode, data: updateContactData} = await put(CONTACT_ENDPOINT + contactId + RqUidQueryParam, JSON.stringify(data), header);
+    const {code: updateContactCode} = await put(CONTACT_ENDPOINT + contactId, JSON.stringify(data), header);
     expect(updateContactCode).toBe(expectedCode);
-    expect(updateContactData.RqUid).toBe(RqUid);
     await checkCurrentContacts([...getAllExpected, testContact]);
   }
 });
@@ -134,43 +126,37 @@ test('/v1/contact bad updated contact', async () => {
 test('/v1/contact bad deleted contact', async () => {
   await checkCurrentContacts(getAllExpected);
   const testContact = {title: 'Ztest', url: 'http://example.com'};
-  const {data: {contactId}} = await post(CONTACT_ENDPOINT + RqUidQueryParam, JSON.stringify(testContact), header);
+  const {data: {contactId}} = await post(CONTACT_ENDPOINT, JSON.stringify(testContact), header);
 
   // contactId is not uuid
   await check('0', 400);
   // contactId does not exist - there is no record with given contactId so 200
   await check('00000000-1111-2222-3333-000000000007', 200);
 
-  await del(CONTACT_ENDPOINT + contactId + RqUidQueryParam, header);
+  await del(CONTACT_ENDPOINT + contactId, header);
   await checkCurrentContacts(getAllExpected);
 
   async function check(contactId, expectedCode) {
-    const {code, data} = await del(CONTACT_ENDPOINT + contactId + RqUidQueryParam, header);
+    const {code} = await del(CONTACT_ENDPOINT + contactId, header);
     expect(code).toBe(expectedCode);
-    expect(data.RqUid).toBe(RqUid);
     await checkCurrentContacts([...getAllExpected, testContact]);
   }
 });
 
 test('/v1/contact unauthorized', async () => {
-  const {code: getAllCode, data: getAllData} = await get(CONTACT_ENDPOINT + RqUidQueryParam);
+  const {code: getAllCode} = await get(CONTACT_ENDPOINT);
   expect(getAllCode).toBe(401);
-  expect(getAllData.RqUid).toBe(RqUid);
-  const {code: postCode, data: postData} = await post(CONTACT_ENDPOINT + RqUidQueryParam, JSON.stringify({title: 'title', url: 'http://url'}));
+  const {code: postCode} = await post(CONTACT_ENDPOINT, JSON.stringify({title: 'title', url: 'http://url'}));
   expect(postCode).toBe(401);
-  expect(postData.RqUid).toBe(RqUid);
-  const {code: delCode, data: delData} = await del(CONTACT_ENDPOINT + '00000000-1111-2222-3333-000000000007' + RqUidQueryParam);
+  const {code: delCode} = await del(CONTACT_ENDPOINT + '00000000-1111-2222-3333-000000000007');
   expect(delCode).toBe(401);
-  expect(delData.RqUid).toBe(RqUid);
-  const {code: putCode, data: putData} = await put(CONTACT_ENDPOINT + '00000000-1111-2222-3333-000000000007' + RqUidQueryParam, JSON.stringify({title: 'title', url: 'http://url'}));
+  const {code: putCode} = await put(CONTACT_ENDPOINT + '00000000-1111-2222-3333-000000000007', JSON.stringify({title: 'title', url: 'http://url'}));
   expect(putCode).toBe(401);
-  expect(putData.RqUid).toBe(RqUid);
 });
 
 test('/v1/contact empty title is error', async () => {
   await checkCurrentContacts(getAllExpected);
   const testContact = {title: '', url: 'http://example.com'};
-  const {code, data} = await post(CONTACT_ENDPOINT + RqUidQueryParam, JSON.stringify(testContact), header);
+  const {code} = await post(CONTACT_ENDPOINT, JSON.stringify(testContact), header);
   expect(code).toBe(400);
-  expect(data.RqUid).toBe(RqUid);
 });

--- a/test/v1/emailSender/emailSenderController.spec.js
+++ b/test/v1/emailSender/emailSenderController.spec.js
@@ -13,60 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { post, getHost, getRqUid } = require('../../utils.js');
+const { post, getHost } = require('../../utils.js');
 
 const GENERATE_TOKEN_ENDPOINT = `${getHost()}/v1/auth/magicLink`;
 const SEND_MAGIC_LINK_ENDPOINT = `${getHost()}/v1/email/sendMagicLink`;
-const RqUid = getRqUid();
 
 test('/v1/email/sendMagicLink/', async () => {
   const email = 'iryabinin@gmail.com';
-  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({RqUid, email}));
-  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({RqUid, email, tokenId}));
+  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({email}));
+  const {code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({email, tokenId}));
   expect(code).toBe(200);
-  expect(data.RqUid).toEqual(RqUid);
 });
 
 test('/v1/email/sendMagicLink/ POST without tokenId', async () => {
   const email = 'iryabinin@gmail.com';
-  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({RqUid, email}));
+  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({email}));
   expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
   expect(data.message).toBeDefined();
 });
 
 test('/v1/email/sendMagicLink/ POST incorrect format tokenId', async () => {
   const email = 'iryabinin@gmail.com';
   const tokenId = 'incorrect token';
-  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({RqUid, email, tokenId}));
+  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({email, tokenId}));
   expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
   expect(data.message).toBeDefined();
 });
 
 test('/v1/email/sendMagicLink/ POST without email', async () => {
   const email = 'iryabinin@gmail.com';
-  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({RqUid, email}));
-  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({RqUid, tokenId}));
+  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({email}));
+  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({tokenId}));
   expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
   expect(data.message).toBeDefined();
 });
 
 test('/v1/email/sendMagicLink/ POST incorrect format email', async () => {
   const email = 'iryabinin@gmail.com';
   const incorrectEmail = 'incorrect format';
-  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({RqUid, email}));
-  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({RqUid, email: incorrectEmail, tokenId}));
-  expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
-  expect(data.message).toBeDefined();
-});
-
-test('/v1/email/sendMagicLink/ POST without RqUid', async () => {
-  const email = 'iryabinin@gmail.com';
-  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({RqUid, email}));
-  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({email, tokenId}));
+  const {data: { tokenId }} = await post(GENERATE_TOKEN_ENDPOINT, JSON.stringify({email}));
+  const {data, code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({email: incorrectEmail, tokenId}));
   expect(code).toBe(400);
   expect(data.message).toBeDefined();
 });
@@ -74,6 +60,6 @@ test('/v1/email/sendMagicLink/ POST without RqUid', async () => {
 test('/v1/email/sendMagicLink/ POST non-existed token', async () => {
   const email = 'iryabinin@gmail.com';
   const nonExistedToken = '00000000-0000-0000-0000-000000000000';
-  const {code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({RqUid, email, tokenId: nonExistedToken}));
+  const {code} = await post(SEND_MAGIC_LINK_ENDPOINT, JSON.stringify({email, tokenId: nonExistedToken}));
   expect(code).toBe(404);
 });

--- a/test/v1/friend/friendController.spec.js
+++ b/test/v1/friend/friendController.spec.js
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { post, del, getHost, getRqUid, getAuthHeader } = require('../../utils.js');
+const { post, del, getHost, getAuthHeader } = require('../../utils.js');
 
 const ENDPOINT = `${getHost()}/v1/user/friend`;
-const RqUid = getRqUid();
 const header = getAuthHeader({
   id: '00000000-1111-2222-3333-000000000001',
   fullName: 'Иван Рябинин',
@@ -25,15 +24,13 @@ const header = getAuthHeader({
 test('/v1/user/friend/ POST', async () => {
   const friendId = '00000000-1111-2222-3333-000000000005';
 
-  await del(`${ENDPOINT}/${friendId}?RqUid=${RqUid}`, header);
+  await del(`${ENDPOINT}/${friendId}`, header);
 
-  const {data: addData, code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({RqUid}), header);
+  const {code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({}), header);
   expect(addCode).toBe(201);
-  expect(addData.RqUid).toEqual(RqUid);
 
-  const {data: repeatAddData, code: repeatAddCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({RqUid}), header);
+  const {code: repeatAddCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({}), header);
   expect(repeatAddCode).toBe(209);
-  expect(repeatAddData.RqUid).toEqual(RqUid);
 });
 
 test('/v1/user/friend/ POST friend is not approved', async () => {
@@ -44,7 +41,7 @@ test('/v1/user/friend/ POST friend is not approved', async () => {
   ];
 
   await Promise.all(friendIds.map(async friendId => {
-    const {code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({RqUid}), header);
+    const {code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({}), header);
     expect(addCode).toBe(404);
   }));
 });
@@ -52,20 +49,12 @@ test('/v1/user/friend/ POST friend is not approved', async () => {
 test('/v1/user/friend/ POST friendId is not real', async () => {
   const friendId = '66666666-1111-2222-3333-000000000009';
 
-  const {code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({RqUid}), header);
+  const {code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({}), header);
   expect(addCode).toBe(404);
 });
 
 test('/v1/user/friend/ POST friend is not uuid', async () => {
   const friendId = '1';
-
-  const {data: addData, code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({RqUid}), header);
-  expect(addCode).toBe(400);
-  expect(addData.message).toBeDefined();
-});
-
-test('/v1/user/friend/ POST without RqUid', async () => {
-  const friendId = '00000000-1111-2222-3333-000000000005';
 
   const {data: addData, code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({}), header);
   expect(addCode).toBe(400);
@@ -75,37 +64,25 @@ test('/v1/user/friend/ POST without RqUid', async () => {
 test('/v1/user/friend/ POST without accessToken', async () => {
   const friendId = '00000000-1111-2222-3333-000000000005';
 
-  const {data: addData, code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({RqUid}));
+  const {code: addCode} = await post(`${ENDPOINT}/${friendId}`, JSON.stringify({}));
   expect(addCode).toBe(401);
-  expect(addData.RqUid).toEqual(RqUid);
 });
 
 
 test('/v1/user/friend/ DELETE', async () => {
   const friendId = '00000000-1111-2222-3333-000000000005';
 
-  await post(`${ENDPOINT}/${friendId}`, JSON.stringify({RqUid}), header);
+  await post(`${ENDPOINT}/${friendId}`, JSON.stringify({}), header);
 
-  const {data: deleteData, code: deleteCode} = await del(`${ENDPOINT}/${friendId}?RqUid=${RqUid}`, header);
+  const {code: deleteCode} = await del(`${ENDPOINT}/${friendId}`, header);
   expect(deleteCode).toBe(200);
-  expect(deleteData.RqUid).toEqual(RqUid);
 
-  const {data: repeatDeleteData, code: repeatDeleteCode} = await del(`${ENDPOINT}/${friendId}?RqUid=${RqUid}`, header);
+  const {code: repeatDeleteCode} = await del(`${ENDPOINT}/${friendId}`, header);
   expect(repeatDeleteCode).toBe(209);
-  expect(repeatDeleteData.RqUid).toEqual(RqUid);
 });
 
 test('/v1/user/friend/ DELETE friend is not uuid', async () => {
   const friendId = '1';
-
-  const {data: deleteData, code: deleteCode} = await del(`${ENDPOINT}/${friendId}?RqUid=${RqUid}`, header);
-  expect(deleteCode).toBe(400);
-  expect(deleteData.RqUid).toEqual(RqUid);
-  expect(deleteData.message).toBeDefined();
-});
-
-test('/v1/user/friend/ DELETE without RqUid', async () => {
-  const friendId = '00000000-1111-2222-3333-000000000005';
 
   const {data: deleteData, code: deleteCode} = await del(`${ENDPOINT}/${friendId}`, header);
   expect(deleteCode).toBe(400);
@@ -115,7 +92,6 @@ test('/v1/user/friend/ DELETE without RqUid', async () => {
 test('/v1/user/friend/ DELETE without accessToken', async () => {
   const friendId = '00000000-1111-2222-3333-000000000005';
 
-  const {data: deleteData, code: deleteCode} = await del(`${ENDPOINT}/${friendId}?RqUid=${RqUid}`);
+  const {code: deleteCode} = await del(`${ENDPOINT}/${friendId}`);
   expect(deleteCode).toBe(401);
-  expect(deleteData.RqUid).toEqual(RqUid);
 });

--- a/test/v1/location/locationController.spec.js
+++ b/test/v1/location/locationController.spec.js
@@ -13,56 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { post, getHost, getRqUid, getAuthHeader } = require('../../utils.js');
+const { post, getHost, getAuthHeader } = require('../../utils.js');
 const header = getAuthHeader({
   id: '00000000-1111-2222-3333-000000000001',
   fullName: 'Иван Рябинин',
 });
 const ENDPOINT = `${getHost()}/v1/location/`;
-const RqUid = getRqUid();
 
 test('/v1/location', async () => {
   const userInput = 'Киев';
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, userInput}), header);
+  const {data, code} = await post(ENDPOINT, JSON.stringify({userInput}), header);
   expect(code).toBe(200);
   expect(data.location[0].city).toEqual('Киев');
   expect(data.location[0].country).toEqual('Украина');
-  expect(data.RqUid).toEqual(RqUid);
 });
 
 test('/v1/location POST without userInput', async () => {
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid}), header);
+  const {data, code} = await post(ENDPOINT, JSON.stringify({}), header);
   expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
   expect(data.message).toBeDefined();
 });
 
 test('/v1/location POST first 2 letters', async () => {
   const userInput = 'Ки';
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, userInput}), header);
+  const {data, code} = await post(ENDPOINT, JSON.stringify({userInput}), header);
   expect(code).toBe(200);
   expect(data.location[0].city).toEqual('Кикерино');
   expect(data.location[0].country).toEqual('Россия');
-  expect(data.RqUid).toEqual(RqUid);
-});
-
-test('/v1/location POST without RqUid', async () => {
-  const userInput = 'Киев';
-  const {data, code} = await post(ENDPOINT, JSON.stringify({userInput}), header);
-  expect(code).toBe(400);
-  expect(data.message).toBeDefined();
 });
 
 test('/v1/location POST non-existent city', async () => {
   const userInput = 'nonExistentCity';
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, userInput}), header);
+  const {data, code} = await post(ENDPOINT, JSON.stringify({userInput}), header);
   expect(code).toBe(200);
-  expect(data.RqUid).toEqual(RqUid);
   expect(data.location.length).toEqual(0);
 });
 
 test('/v1/location empty userInput is 400', async () => {
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, userInput: ''}), header);
+  const {code} = await post(ENDPOINT, JSON.stringify({userInput: ''}), header);
   expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
 });

--- a/test/v1/profile/profileController.spec.js
+++ b/test/v1/profile/profileController.spec.js
@@ -13,31 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { post, getHost, getRqUid, getAuthHeader } = require('../../utils.js');
+const { post, getHost, getAuthHeader } = require('../../utils.js');
 
 const ENDPOINT = `${getHost()}/v1/profile/search`;
-const RqUid = getRqUid();
 const header = getAuthHeader({
   id: '00000000-1111-2222-3333-000000000001',
   fullName: 'Иван Рябинин',
 });
 
 test('/v1/search/ POST', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'fullName': 'иван','username': 'иван','location': 'иван'}]};
+  const testEntry = {'perPage': 100,'query': [{'fullName': 'иван','username': 'иван','location': 'иван'}]};
   testEntry.currentPage = 1;
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data[0].username).toEqual('iryabinin');
   expect(getSearchData.entries.data[0].status).toEqual('approved');
 });
 
 test('/v1/search/ POST two correct words: firstName and lastName', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'fullName': 'иван'},{'fullName': 'Рябинин'}]};
+  const testEntry = {'perPage': 100,'query': [{'fullName': 'иван'},{'fullName': 'Рябинин'}]};
   testEntry.currentPage = 1;
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data[0].username).toEqual('iryabinin');
   expect(getSearchData.entries.data[0].fullName).toEqual('Иван Рябинин');
   expect(getSearchData.entries.data[0].imagePath).toEqual('https://store.playstation.com/store/api/chihiro/00_09_000/container/IN/en/999/EP1257-CUSA07617_00-AV00000000000004/1586170996000/image?w=240&h=240&bg_color=000000&opacity=100&_version=00_09_000');
@@ -46,111 +43,93 @@ test('/v1/search/ POST two correct words: firstName and lastName', async () => {
 });
 
 test('/v1/search/ POST two words: firstName and wrong lastName', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'fullName': 'иван'},{'fullName': 'Рябинович'}]};
+  const testEntry = {'perPage': 100,'query': [{'fullName': 'иван'},{'fullName': 'Рябинович'}]};
   testEntry.currentPage = 1;
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data).toEqual([]);
 });
 
 test('/v1/search/ POST param that does not exists', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'gender': 'девушка'}]};
+  const testEntry = {'perPage': 100,'query': [{'gender': 'девушка'}]};
   testEntry.currentPage = 1;
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data).not.toEqual([]);
 });
 
 test('/v1/search/ POST without perPage and currentPage and with empty query', async () => {
-  const testEntry = {RqUid,'query': []};
+  const testEntry = {'query': []};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data).not.toEqual([]);
 });
 
 
 test('/v1/search/ POST with wrong page number', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'fullName': 'Иван','username': 'Иван','location': 'Иван'}]};
+  const testEntry = {'perPage': 100,'query': [{'fullName': 'Иван','username': 'Иван','location': 'Иван'}]};
   testEntry.currentPage = 2;
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data).toEqual([]);
 });
 
 test('/v1/search/ POST with no existing user', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'fullName': '///','username': '///','location': '///'}]};
+  const testEntry = {'perPage': 100,'query': [{'fullName': '///','username': '///','location': '///'}]};
   testEntry.currentPage = 1;
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data).toEqual([]);
 });
 
 test('/v1/search/ POST with sql injection attempt', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'fullName': `иван'+OR+1=1--`,'username': `иван'+OR+1=1--`,'location': `иван'+OR+1=1--`}]};
+  const testEntry = {'perPage': 100,'query': [{'fullName': `иван'+OR+1=1--`,'username': `иван'+OR+1=1--`,'location': `иван'+OR+1=1--`}]};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data).toEqual([]);
 });
 
 test('/v1/search/ POST with skills', async () => {
-  const testEntry = {RqUid,'perPage': 100,'query': [{'skill': 'Offic'}]};
+  const testEntry = {'perPage': 100,'query': [{'skill': 'Offic'}]};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry),header);
   expect(searchCode).toBe(200);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.entries.data[0].skills[0]).toEqual('Improvements');
 });
 
 test('/v1/search/ POST with exceed the limit', async () => {
-  const testEntry = {RqUid,'perPage': 1001,'query': [{'fullName': 'Иван','username': 'Иван','location': 'Иван'}]};
+  const testEntry = {'perPage': 1001,'query': [{'fullName': 'Иван','username': 'Иван','location': 'Иван'}]};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(400);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.message).toEqual('should be <= 1000');
 });
 
 test('/v1/search/ POST with array parameter which exceed the limit:username', async () => {
-  const testEntry = {RqUid,'perPage': 20,'query': [{'fullName': '1234567890123456789012345678903333','username': '1234567890123456789012345678903333','location': '1234567890123456789012345678903333'}]};
+  const testEntry = {'perPage': 20,'query': [{'fullName': '1234567890123456789012345678903333','username': '1234567890123456789012345678903333','location': '1234567890123456789012345678903333'}]};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(400);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.message).toEqual('should NOT be longer than 30 characters');
 });
 
 test('/v1/search/ POST with array parameter which exceed the limit: fullname', async () => {
   const longName = new Array(257).join('a');
-  const testEntry = {RqUid,'perPage': 20,'query': [{'fullName': longName}]};
+  const testEntry = {'perPage': 20,'query': [{'fullName': longName}]};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(400);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.message).toEqual('should NOT be longer than 255 characters');
 });
 
 test('/v1/search/ POST without perPage and currentPage and with empty query', async () => {
-  const testEntry = {RqUid,'query': 'text'};
+  const testEntry = {'query': 'text'};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(400);
-  expect(getSearchData.RqUid).toEqual(RqUid);
   expect(getSearchData.message).toEqual('should be array');
 });
 
 test('/v1/search/ POST without query', async () => {
-  const testEntry = {RqUid,'perPage': 100};
+  const testEntry = {'perPage': 100};
   const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
   expect(searchCode).toBe(400);
   expect(getSearchData.message).toEqual(`should have required property 'query'`);
-});
-
-test('/v1/search/ POST without RqUid', async () => {
-  const testEntry = {'perPage': 100,'query': [{'fullName': 'Иван','username': 'Иван','location': 'Иван'}]};
-  const {data: getSearchData, code: searchCode} = await post(ENDPOINT, JSON.stringify(testEntry), header);
-  expect(searchCode).toBe(400);
-  expect(getSearchData.message).toEqual(`should have required property 'RqUid'`);
 });
 
 test('/v1/search/ POST without access token', async () => {
@@ -179,8 +158,7 @@ test('/v1/search/ POST emtpy string is 400', async () => {
   await check([{skills: ''}]);
 
   async function check(query) {
-    const {code, data} = await post(ENDPOINT, JSON.stringify({RqUid, query: query}), header);
+    const {code} = await post(ENDPOINT, JSON.stringify({query: query}), header);
     expect(code).toBe(400);
-    expect(data.RqUid).toBe(RqUid);
   }
 });

--- a/test/v1/profile/saveUserDetailsController.spec.js
+++ b/test/v1/profile/saveUserDetailsController.spec.js
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { put, get, getHost, getRqUid, getAuthHeader } = require('../../utils.js');
+const { put, get, getHost, getAuthHeader } = require('../../utils.js');
 const header = getAuthHeader({
   id: '00000000-1111-2222-3333-000000000008',
   fullName: 'Volodymyr',
 });
 
 const ENDPOINT = `${getHost()}/v1/user`;
-const RqUid = getRqUid();
 const about = 'Я пишу о себе';
 const location = 'Киев, Украина';
 const skills = ['Improvements'];
@@ -29,22 +28,20 @@ const fullName = 'Volodymyr';
 const imagePath = 'https://a.png';
 
 test('/v1/user', async () => {
-  const {data, code} = await put(ENDPOINT, JSON.stringify({RqUid, location, about, skills, role, fullName, imagePath }), header);
+  const {code} = await put(ENDPOINT, JSON.stringify({location, about, skills, role, fullName, imagePath }), header);
   expect(code).toBe(200);
-  expect(data.RqUid).toEqual(RqUid);
 
-  const {data: {user}} = await get(ENDPOINT + '?RqUid=' + RqUid, header);
+  const {data: {user}} = await get(ENDPOINT, header);
   expect(user.fullName).toBe(fullName);
   expect(user.role).toBe(role);
   expect(user.about).toBe(about);
   expect(user.imagePath).toBe(imagePath);
 
 
-  const {data: saveUserWithoutRoleData, code: saveUserWithoutRoleCode} = await put(ENDPOINT, JSON.stringify({RqUid, location, about, skills, fullName, imagePath }), header);
+  const {code: saveUserWithoutRoleCode} = await put(ENDPOINT, JSON.stringify({location, about, skills, fullName, imagePath }), header);
   expect(saveUserWithoutRoleCode).toBe(200);
-  expect(saveUserWithoutRoleData.RqUid).toEqual(RqUid);
 
-  const {data: {user: userWithoutRole}} = await get(ENDPOINT + '?RqUid=' + RqUid, header);
+  const {data: {user: userWithoutRole}} = await get(ENDPOINT, header);
   expect(userWithoutRole.fullName).toBe(fullName);
   expect(userWithoutRole.role).toBe(null);
   expect(userWithoutRole.about).toBe(about);
@@ -52,13 +49,7 @@ test('/v1/user', async () => {
 });
 
 test('/v1/user PUT without userInput', async () => {
-  const {data, code} = await put(ENDPOINT, JSON.stringify({RqUid}), header);
-  expect(code).toBe(400);
-  expect(data.RqUid).toEqual(RqUid);
-});
-
-test('/v1/user PUT without RqUid', async () => {
-  const {code} = await put(ENDPOINT, JSON.stringify({location, about, skills, role, fullName}), header);
+  const {code} = await put(ENDPOINT, JSON.stringify({}), header);
   expect(code).toBe(400);
 });
 
@@ -66,7 +57,7 @@ test('/v1/user PUT skills are not an array', async () => {
   const about = 'Я пишу о себе';
   const location =  'Киев, Украина';
   const skills = 'not an array';
-  const {data, code} = await put(ENDPOINT, JSON.stringify({RqUid, location, about, skills}), header);
+  const {data, code} = await put(ENDPOINT, JSON.stringify({location, about, skills}), header);
   expect(code).toBe(400);
   expect(data.message).toBeDefined();
 });
@@ -76,21 +67,20 @@ test('/v1/user PUT skill item is not a string', async () => {
   const about = 'Я пишу о себе';
   const location =  'Киев, Украина';
   const skills = [1, 2, 3];
-  const {data, code} = await put(ENDPOINT, JSON.stringify({RqUid, location, about, skills}), header);
+  const {data, code} = await put(ENDPOINT, JSON.stringify({location, about, skills}), header);
   expect(code).toBe(400);
   expect(data.message).toBeDefined();
 });
 
 test('/v1/user empty string is 400', async () => {
-  await check({RqUid, location: ''});
-  await check({RqUid, about: ''});
-  await check({RqUid, fullName: ''});
-  await check({RqUid, role: ''});
-  await check({RqUid, skills: ['']});
+  await check({location: ''});
+  await check({about: ''});
+  await check({fullName: ''});
+  await check({role: ''});
+  await check({skills: ['']});
 
   async function check(updatedData) {
-    const {data, code} = await put(ENDPOINT, JSON.stringify(updatedData), header);
+    const {code} = await put(ENDPOINT, JSON.stringify(updatedData), header);
     expect(code).toBe(400);
-    expect(data.RqUid).toEqual(RqUid);
   }
 });

--- a/test/v1/profile/uploadImageController.spec.js
+++ b/test/v1/profile/uploadImageController.spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const { post, getHost, getRqUid, getAuthHeader } = require('../../utils.js');
+const { post, getHost, getAuthHeader } = require('../../utils.js');
 const http = require('http');
 
 const fs = require('fs');
@@ -25,12 +25,6 @@ const TEST_FILE = './test/v1/profile/data/test-avatar.jpg';
 const authHeader = getAuthHeader({
   id: '00000000-1111-2222-3333-000000000001',
   fullName: 'Иван Рябинин',
-});
-
-test('/v1/profile/uploadImage POST without RqUid', async () => {
-  const {data, code} = await post(ENDPOINT, JSON.stringify({}), authHeader);
-  expect(code).toBe(400);
-  expect(data.message).toBeDefined();
 });
 
 test('/v1/profile/uploadImage POST with invalid MIME type', async () => {
@@ -86,7 +80,7 @@ function uploadImage(file, mimeType) {
 
   let requestFinished;
   const requestPromise = new Promise(resolve => requestFinished = resolve);
-  const req = http.request(ENDPOINT + '?RqUid=' + getRqUid(), { method: 'POST', headers: { ...form.getHeaders(), ...authHeader } }, res => {
+  const req = http.request(ENDPOINT, { method: 'POST', headers: { ...form.getHeaders(), ...authHeader, 'X-Request-Id': 'd5ab3356-f4b4-11ea-adc1-0242ac120002' } }, res => {
     let data = '';
     res.on('data', chunk => data += chunk);
     res.on('end', () => {

--- a/test/v1/test/testController.spec.js
+++ b/test/v1/test/testController.spec.js
@@ -13,61 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { get, post, put, del, getHost, getRqUid } = require('../../utils.js');
+const { get, post, put, del, getHost } = require('../../utils.js');
 
 const ENDPOINT = `${getHost()}/v1/test/`;
-const RqUid = getRqUid();
 
 test('/v1/test/:id', async () => {
   const testEntry = {
     fieldA: 42,
     fieldB: 'abc'
   };
-  const {data: createData, code: createCode} = await post(ENDPOINT, JSON.stringify({RqUid, ...testEntry}));
+  const {data: createData, code: createCode} = await post(ENDPOINT, JSON.stringify({...testEntry}));
   expect(createCode).toBe(200);
-  expect(createData.RqUid).toEqual(RqUid);
   expect(createData.id).toBeDefined();
 
-  const {data: getData, code: getCode} = await get(ENDPOINT + createData.id + `?RqUid=${RqUid}`);
+  const {data: getData, code: getCode} = await get(ENDPOINT + createData.id);
   expect(getCode).toBe(200);
-  expect(getData).toEqual({id: createData.id, RqUid, ...testEntry});
+  expect(getData).toEqual({id: createData.id, ...testEntry});
 
   testEntry.fieldA = 239;
   testEntry.fieldB = 'cba';
-  const {data: updateData, code: updateCode} = await put(ENDPOINT + createData.id, JSON.stringify({RqUid, ...testEntry}));
+  const {code: updateCode} = await put(ENDPOINT + createData.id, JSON.stringify({...testEntry}));
   expect(updateCode).toBe(200);
-  expect(updateData.RqUid).toEqual(RqUid);
 
-  const {data: getDataAfterUpdate, code: getCodeAfterUpdate} = await get(ENDPOINT + createData.id + `?RqUid=${RqUid}`);
+  const {data: getDataAfterUpdate, code: getCodeAfterUpdate} = await get(ENDPOINT + createData.id);
   expect(getCodeAfterUpdate).toBe(200);
-  expect(getDataAfterUpdate).toEqual({id: createData.id, RqUid, ...testEntry});
-  expect(getDataAfterUpdate.RqUid).toEqual(RqUid);
+  expect(getDataAfterUpdate).toEqual({id: createData.id, ...testEntry});
 
-  const {code: deleteCode, data: deleteData} = await del(ENDPOINT + createData.id + `?RqUid=${RqUid}`);
+  const {code: deleteCode} = await del(ENDPOINT + createData.id);
   expect(deleteCode).toBe(200);
-  expect(deleteData.RqUid).toBeDefined();
 
-  const {code: getCodeAfterDelete, data: getDataAfterDelete} = await get(ENDPOINT + createData.id + `?RqUid=${RqUid}`);
+  const {code: getCodeAfterDelete} = await get(ENDPOINT + createData.id);
   expect(getCodeAfterDelete).toBe(404);
-  expect(getDataAfterDelete.RqUid).toEqual(RqUid);
 });
 
 test('/v1/test/ POST without fieldA', async () => {
-  const {data, code} = await post(ENDPOINT, JSON.stringify({RqUid, fieldB: 'abc'}));
+  const {data, code} = await post(ENDPOINT, JSON.stringify({fieldB: 'abc'}));
   expect(code).toBe(400);
   expect(data.message).toBeDefined();
-});
-
-test('/v1/test/ POST without RqUid', async () => {
-  const {data, code} = await post(ENDPOINT, JSON.stringify({fieldA: 42, fieldB: 'abc'}));
-  expect(code).toBe(400);
-  expect(data.message).toBeDefined();
-  // TODO(ak239spb): it should work
-  // expect(data.RqUid).toBeDefined();
 });
 
 test('/v1/test/:id GET with id that does not exist', async () => {
-  const {data, code} = await get(ENDPOINT + '1234567' + `?RqUid=${RqUid}`);
+  const {code} = await get(ENDPOINT + '1234567');
   expect(code).toBe(404);
-  expect(data.RqUid).toBeDefined();
 });

--- a/test/v1/users/usersController.spec.js
+++ b/test/v1/users/usersController.spec.js
@@ -13,23 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { get, del, post, getHost, getRqUid, getAuthHeader } = require('../../utils.js');
+const { get, del, post, getHost, getAuthHeader } = require('../../utils.js');
 
 const USER_ENDPOINT = `${getHost()}/v1/user`;
 const USERS_ENDPOINT = `${getHost()}/v1/users/`;
 const FRIEND_ENDPOINT = `${getHost()}/v1/user/friend`;
 
-const RqUid = getRqUid();
-const RqUidQueryParam = '?RqUid=' + RqUid;
 const header = getAuthHeader({
   id: '00000000-1111-2222-3333-000000000001',
   fullName: 'Иван Рябинин',
 });
 
 test('GET /v1/users/:id', async () => {
-  const {data, code} = await get(USERS_ENDPOINT + '00000000-1111-2222-3333-000000000001' + RqUidQueryParam, header);
+  const {data, code} = await get(USERS_ENDPOINT + '00000000-1111-2222-3333-000000000001', header);
   expect(code).toBe(200);
-  expect(data.RqUid).toEqual(RqUid);
   const user = data.user;
   expect(user.id).toEqual('00000000-1111-2222-3333-000000000001');
   expect(user.fullName).toEqual('Иван Рябинин');
@@ -42,19 +39,18 @@ test('GET /v1/users/:id', async () => {
 test('GET /v1/users/:id has friend', async () => {
   const friendId = '00000000-1111-2222-3333-000000000005';
 
-  await del(`${FRIEND_ENDPOINT}/${friendId}?RqUid=${RqUid}`, header);
-  await post(`${FRIEND_ENDPOINT}/${friendId}?RqUid=${RqUid}`, '', header);
+  await del(`${FRIEND_ENDPOINT}/${friendId}`, header);
+  await post(`${FRIEND_ENDPOINT}/${friendId}`, '', header);
 
-  const {data, code} = await get(USERS_ENDPOINT + friendId + RqUidQueryParam, header);
+  const {data, code} = await get(USERS_ENDPOINT + friendId, header);
   expect(code).toBe(200);
   const user = data.user;
   expect(user.isFriend).toBeTruthy();
 });
 
 test('GET /v1/user', async () => {
-  const {data, code} = await get(USER_ENDPOINT + RqUidQueryParam, header);
+  const {data, code} = await get(USER_ENDPOINT, header);
   expect(code).toBe(200);
-  expect(data.RqUid).toEqual(RqUid);
   const user = data.user;
   expect(user.id).toEqual('00000000-1111-2222-3333-000000000001');
   expect(user.email).toEqual('iryabinin@gmail.com');
@@ -70,23 +66,23 @@ test('GET /v1/user', async () => {
 });
 
 test('GET /v1/users/:id with invalid id', async () => {
-  const {code} = await get(USERS_ENDPOINT + '100' + RqUidQueryParam, header);
+  const {code} = await get(USERS_ENDPOINT + '100', header);
   expect(code).toBe(400);
 });
 
 test('GET /v1/users/:id without contact', async () => {
-  const {code, data} = await get(USERS_ENDPOINT + '00000000-1111-2222-3333-000000000005' + RqUidQueryParam, header);
+  const {code, data} = await get(USERS_ENDPOINT + '00000000-1111-2222-3333-000000000005', header);
   expect(code).toBe(200);
   const user = data.user;
   expect(user.contacts).toEqual([]);
 });
 
 test('GET /v1/users/:id with rejected id', async () => {
-  const {code} = await get(USERS_ENDPOINT + '00000000-1111-2222-3333-000000000003' + RqUidQueryParam, header);
+  const {code} = await get(USERS_ENDPOINT + '00000000-1111-2222-3333-000000000003', header);
   expect(code).toBe(404);
 });
 
 test('GET /v1/users/:id with unknown id', async () => {
-  const {code} = await get(USERS_ENDPOINT + '99000000-1111-2222-3333-000000000001' + RqUidQueryParam, header);
+  const {code} = await get(USERS_ENDPOINT + '99000000-1111-2222-3333-000000000001', header);
   expect(code).toBe(404);
 });


### PR DESCRIPTION
Каждый запрос обязан содержать этот хедер, значение должно быть uuid.
Временно продолжаем поддерживать RqUid в качестве альтернативы -
до тех пор пока фронтенд не начнет использовать X-Request-Id.