### PR TITLE
fix(contact): не требовать uri в url для контакта

### DIFF
--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -225,7 +225,7 @@
       "allOf": [{ "$ref": "#RequestBase" }],
       "properties": {
         "title": { "type": "string", "maxLength": 64, "minLength": 1 },
-        "url": { "type": "string", "format": "uri", "maxLength": 255, "minLength": 1 }
+        "url": { "type": "string", "maxLength": 255, "minLength": 1 }
       },
       "required": [ "title", "url" ]
     },
@@ -235,7 +235,7 @@
       "properties": {
         "contactId": { "type": "string", "format": "uuid" },
         "title": { "type": "string", "maxLength": 64, "minLength": 1 },
-        "url": { "type": "string", "format": "uri", "maxLength": 255, "minLength": 1 }
+        "url": { "type": "string", "maxLength": 255, "minLength": 1 }
       },
       "required": [ "contactId", "title", "url" ]
     },

--- a/test/v1/contact/contactController.spec.js
+++ b/test/v1/contact/contactController.spec.js
@@ -62,7 +62,7 @@ test('/v1/contact', async () => {
   await checkCurrentContacts([...getAllExpected, newContactDataExpected]);
 
   // check that we can edit contact
-  const updatedNewContactExpected = {title: 'Zmytitle', url: 'http://myurl'};
+  const updatedNewContactExpected = {title: 'Zmytitle', url: 'myurl'};
   const {code: updateContactCode} = await put(CONTACT_ENDPOINT + newContactData.contactId, JSON.stringify(updatedNewContactExpected), header);
   expect(updateContactCode).toBe(200);
 
@@ -82,9 +82,6 @@ test('/v1/contact bad new contact', async () => {
   await check({title: 'mytitle'});
   // no title
   await check({url: 'http://myurl'});
-  // url is not url
-  await check({title: 'abc', url: 'url'});
-  await check({title: 'abc', url: '@handle'});
   // long title
   await check({title: 'x'.repeat(1024), url: 'http://myurl'});
   // long url


### PR DESCRIPTION
Если пользователь хочет ввести не url, то это временно его право,
в будущем мы должны валидировать это на фронтенде и вернуть эту
проверку обратно.