### PR TITLE
feat: GET /v1/database/getSkills

### DIFF
--- a/seeds/01_users.js
+++ b/seeds/01_users.js
@@ -247,6 +247,20 @@ exports.seed = async function(knex) {
             busy: true,
             status: 'approved',
             skills: []
+          },
+          {
+            id: knex.raw('\'00000000-1111-2222-3333-000000000018\'::uuid'),
+            fullName: 'Навык Навык',
+            username: 'user18',
+            role: 'skill_role',
+            email: 'user18@gmail.com',
+            passwordHash: 'HASH',
+            imagePath: 'https://example.com/a.png',
+            about: 'Все в навыках',
+            location: 'Magadan',
+            busy: true,
+            status: 'approved',
+            skills: ['test_skillA', 'test_skillB', 'test_skillC', 'test_skillAb', 'test_skillМощь']
           }
         ]);
       });

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import {UploadImageController} from './controllers/uploadImageController';
 import {FriendEntryController} from './controllers/friendController';
 import {LocationsController} from './controllers/locationController';
 import {SingleContactController, AllContactsController} from './controllers/contactController';
+import {GetSkillsController} from './controllers/databaseController';
 
 import { errorHandler, notFoundHandler } from './errorHandler';
 import {accessTokenHandler} from './accessTokenHandler';
@@ -61,7 +62,6 @@ register(app, '/v1/email/sendMagicLink', EmailMagicLinkSenderController);
 
 // all endpoints closed by authentication below this line
 
-// Profiles end-points
 register(app, '/v1/user/friend/:friendId', FriendEntryController, true);
 register(app, '/v1/users/:id', UsersController, true);
 register(app, '/v1/user', UserController, true);
@@ -70,6 +70,8 @@ register(app, '/v1/profile/search/', ProfileController, true);
 register(app, '/v1/location/', LocationsController, true);
 register(app, '/v1/contact/:contactId', SingleContactController, true);
 register(app, '/v1/contact', AllContactsController, true);
+
+register(app, '/v1/database/getSkills', GetSkillsController, true);
 
 // endpoints below are available only for admin account
 register(app, '/v1/admin/invalidateSearchIndex', InvalidateSearchIndexController, true);

--- a/src/controllers/databaseController.ts
+++ b/src/controllers/databaseController.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { getArgs } from '../utils';
+import knex from '../knex';
+
+const getSkills = express.Router();
+getSkills.route('/')
+    .get(async (request, response) => {
+      try {
+        const {q, offset, count} = getArgs(request);
+        const {rows}: {rows: {skill: string, total: string}[]} = await knex.raw(`
+          SELECT s.skill as skill FROM 
+          (SELECT lower(unnest(skills)) as skill FROM "User") s
+          GROUP BY s.skill HAVING s.skill like concat(?::text, '%')
+          LIMIT ? OFFSET ?`, [q, count, offset]);
+        const {rows: [{count: total}]}: {rows: {count: string}[]} = await knex.raw(`
+          SELECT COUNT(DISTINCT skill)
+          FROM (SELECT LOWER(unnest(skills)) as skill FROM "User") s
+          WHERE skill like concat(?::text, '%')`, [q]);
+        response.status(200).send({
+          count: parseInt(total, 10),
+          items: rows.map(row => row.skill)
+        });
+      } catch (e) {
+        console.debug('/v1/database/getSkills error', e);
+        response.status(500).json({}).end();
+      }
+    });
+
+export {
+  getSkills as GetSkillsController
+};

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -248,5 +248,14 @@
     {
       "$id": "#GET>/v1/admin/invalidateSearchIndex",
       "allOf": [{ "$ref": "#RequestBase" }]
+    },
+    {
+      "$id": "#GET>/v1/database/getSkills",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "q": { "type": "string", "default": "", "maxLength": 15 },
+        "offset": { "type": "integer", "default": 0, "minimum": 0 },
+        "count": { "type": "integer", "default": 10, "minimum": 0 }
+      }
     }
 ]

--- a/test/v1/databaseController.spec.js
+++ b/test/v1/databaseController.spec.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { get, getAuthHeader, getHost } = require('../utils.js');
+
+const authHeader = getAuthHeader({
+  id: '00000000-1111-2222-3333-000000000001',
+  fullName: 'Иван Рябинин',
+});
+
+test('GET /v1/database/getSkills', async () => {
+  await check('test_skill', 0, 100, 200, 5, ['test_skilla', 'test_skillab', 'test_skillb', 'test_skillc', 'test_skillмощь']);
+  await check('test_skill', 0, 1, 200, 5, ['test_skilla']);
+  await check('test_skill', 1, 1, 200, 5, ['test_skillab']);
+  await check('test_skill', 2, 1, 200, 5, ['test_skillb']);
+  await check('test_skilla', 0, 3, 200, 2, ['test_skilla', 'test_skillab']);
+  await check('test_skill', 100000, 10, 200, 5, []);
+  await check('test_skill', -100, 10, 400, 0, []);
+  await check('test_skill', 5.5, 10, 400, 0, []);
+  await check('test_skill', 0, -10, 400, 0, []);
+  await check('test_skill', 0, 5.5, 400, 0, []);
+  await check('a'.repeat(15), 0, 10, 200, 0, []);
+  await check('a'.repeat(16), 0, 10, 400, 0, []);
+
+  {
+    const url = `${getHost()}/v1/database/getSkills`;
+    const {code, data} = await get(url, authHeader);
+    expect(code).toBe(200);
+    // with empty q - we return all skills
+    expect(data.count).toBeGreaterThan(0);
+    // default count is 10
+    expect(data.items.length).toBe(10);
+  }
+
+  // await check('м', 0, 100, 200, 2, []);
+
+  async function check(q, offset, count, expectedCode, expectedCount, expectedItems) {
+    const fields = [];
+    if (q !== undefined)
+      fields.push('q=' + encodeURIComponent(q));
+    if (offset !== undefined)
+      fields.push('offset=' + encodeURIComponent(offset + ''));
+    if (count !== undefined)
+      fields.push('count=' + encodeURIComponent(count + ''));
+    const url = `${getHost()}/v1/database/getSkills?${fields.join('&')}`;
+    const {code, data} = await get(url, authHeader);
+    expect(code).toEqual(expectedCode);
+    if (code === 200) {
+      expect(data.count).toEqual(expectedCount);
+      expect(data.items.sort()).toStrictEqual(expectedItems.sort());
+    }
+  }
+});


### PR DESCRIPTION
Вдохновение для названия и формата черпал из API vkontakte:
https://vk.com/dev.php?method=database.getCities

GET /v1/database/getSkills принимает три опциональные поля:
- q - строка, максмальная длина - 15 символов, '' по умолчанию,
- offset - целое число, минимальное значение - 0, 0 по умолчанию,
- limit - целое число, минимальное значение - 0, 10 по умолчанию.

Возвращает:
{
  count: integer, // сколько всего есть записей
  items: ['skill1', 'skill2'] // навыки, приведенные к нижнему регистру
}

Навык sKiLl и skill - один и тот же навык.