### PR TITLE
feat: User.placeId, POST /v1/locations breaking change

### DIFF
--- a/migrations/20201015180937_user_place_id.js
+++ b/migrations/20201015180937_user_place_id.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = function(knex) {
+  return knex.raw('ALTER TABLE "User" ADD COLUMN place_id TEXT NULL;');
+};
+
+exports.down = function(knex) {
+  return knex.raw('ALTER TABLE "User" DROP COLUMN place_id');
+};

--- a/seeds/01_users.js
+++ b/seeds/01_users.js
@@ -261,6 +261,21 @@ exports.seed = async function(knex) {
             busy: true,
             status: 'approved',
             skills: ['test_skillA', 'test_skillB', 'test_skillC', 'test_skillAb', 'test_skillМощь']
+          },
+          {
+            id: knex.raw('\'00000000-1111-2222-3333-000000000019\'::uuid'),
+            fullName: 'placeIdTest',
+            username: 'user19',
+            role: null,
+            email: 'user19@gmail.com',
+            passwordHash: null,
+            imagePath: 'https://example.com/a.png',
+            about: 'Местный',
+            location: 'Magadan',
+            place_id: 'placeid',
+            busy: true,
+            status: 'approved',
+            skills: []
           }
         ]);
       });

--- a/src/controllers/locationController.ts
+++ b/src/controllers/locationController.ts
@@ -49,7 +49,10 @@ router.route('/')
               }
             });
           }));
-          const location = result.predictions.map((prediction: any) => prediction.description);
+          const location = result.predictions.map((prediction: {description: string, place_id: string}) => ({
+            description: prediction.description,
+            placeId: prediction.place_id
+          }));
           response.status(200).json({location}).end();
         } catch (error) {
           console.debug('POST /v1/location', error);

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -13,66 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * @typedef {Object} UserEntries
- * @property {string} location
- * @property {string} userName
- * @property {string} role
- * @property {string} about
- * @property {string} fullName
- * @property {Array} skills
- *
- * @returns {Knex.QueryBuilder<UserTable, {}>}
- */
+
 import express from 'express';
-import Knex from 'knex';
 import { UserStatus } from '../enums/UserStatus';
 import knex from '../knex';
 import {invalidateSearchIndex} from '../search';
 
 import {getArgs} from '../utils';
 
-const UserEntries = () => knex('User');
-const ContactEntries = () => knex('Contact');
-const FriendEntries = () => knex('Friend');
+interface Contact {
+  title: string;
+  url: string;
+}
+
+interface User {
+  id: string;
+  fullName: string;
+  username: string|null|undefined;
+  email: string|undefined;
+  imagePath: string|null|undefined;
+  location: string|null|undefined;
+  placeId: string|null|undefined;
+  about: string|null|undefined;
+  role: string|null|undefined;
+  skills: string[];
+  status: string;
+  busy: boolean;
+}
 
 const handleUserRequestById = async (id: string, selfInfo: boolean, request: any, response: any) => {
   try {
-    const contactsPromise = ContactEntries()
-        .select([
-          'title',
-          'url'
-        ])
-        .where('ownerId', id);
-    const userPromise = UserEntries()
-        .select([
-          'id',
-          'fullName',
-          'username',
-          selfInfo ? 'email' : null,
-          'imagePath',
-          'location',
-          'about',
-          'role',
-          'skills',
-          'status',
-          'busy'
-        ].filter(t => !!t))
-        .first()
-        .where((builder: Knex.QueryBuilder) => {
-          // if (!selfInfo)
-          builder.where('status', UserStatus.APPROVED);
+    const contactsPromise = knex.raw(`SELECT title, url FROM "Contact" WHERE "ownerId" = ?`, [id])
+        .then((result: {rows: Contact[]}) => result.rows);
 
-          builder.where('id', id);
-        });
+    const userPromise = knex.raw(`
+      SELECT id, "fullName", username, ${selfInfo ? 'email,' : ''} "imagePath", location, place_id as "placeId", about, role, skills, status, busy
+      FROM "User" WHERE status = ? AND id = ? LIMIT 1`, [UserStatus.APPROVED, id])
+        .then((result: {rows: User[]}) => result.rows.length > 0 ? removeNulls(result.rows[0]) : null);
 
-    const isFriendPromise = selfInfo ? null :
-      await FriendEntries()
-          .select('id')
-          .first()
-          .where('userId', request.user!.id!)
-          .andWhere('friendId', id);
-
+    const isFriendPromise = selfInfo ? false : knex.raw(`SELECT EXISTS(SELECT 1 FROM "Friend" WHERE "userId" = ? AND "friendId" = ?)`, [request.user!.id!, id])
+        .then((result: {rows: {exists: boolean}[]}) => result.rows.length > 0 ? result.rows[0].exists : false);
     const [contacts, user, isFriend] = (await Promise.allSettled([contactsPromise, userPromise, isFriendPromise])).map(result => result.status === 'fulfilled' ? result.value : null);
 
     if (!user)
@@ -91,6 +71,22 @@ const handleUserRequestById = async (id: string, selfInfo: boolean, request: any
     console.debug('handleUserRequestById error', e);
     response.status(500).json({}).end();
   }
+
+  function removeNulls(user: User) {
+    if (user.username === null)
+      delete user.username;
+    if (user.imagePath === null)
+      delete user.imagePath;
+    if (user.location === null)
+      delete user.location;
+    if (user.placeId === null)
+      delete user.placeId;
+    if (user.about === null)
+      delete user.about;
+    if (user.role === null)
+      delete user.role;
+    return user;
+  }
 };
 
 const usersController = express.Router();
@@ -106,19 +102,14 @@ userController.route('/')
       await handleUserRequestById(request.user!.id!, true, request, response);
     })
     .put(async (request, response) => {
-      const { location, role = null, about, fullName, skills = null, imagePath, busy } = getArgs(request);
+      const { location, role = null, about, fullName, skills = null, imagePath = null, busy = false, placeId = null } = getArgs(request);
       if (request.user) {
         try {
           const id = request.user.id;
-          await UserEntries().where('id', id).update({
-            about,
-            location,
-            role,
-            fullName,
-            skills,
-            imagePath,
-            busy
-          });
+          await knex.raw(`
+            UPDATE "User" SET about = :about, location = :location, place_id = :placeId, role = :role, "fullName" = :fullName,
+            skills = :skills, "imagePath" = :imagePath, busy = :busy WHERE id = :id`,
+          { about, location, placeId, role, fullName, skills, imagePath, busy, id });
           await invalidateSearchIndex(id);
           response.status(200).json({}).end();
         } catch (error) {

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -179,6 +179,10 @@
             "maxLength":255,
             "minLength": 1
           },
+          "placeId": {
+            "type": "string",
+            "isStringNotEmpty": true
+          },
           "about": {
             "type": "string",
             "maxLength":6000,

--- a/test/v1/location/locationController.spec.js
+++ b/test/v1/location/locationController.spec.js
@@ -55,11 +55,11 @@ test('/v1/location empty userInput is 400', async () => {
 });
 
 // TODO(ak239spb): it should be a way to mock google places API in some nice way.
-// test('/v1/location POST with sessionToken', async() => {
+// test('/v1/location POST with sessionToken', async () => {
 //   const userInput = 'Ки';
 //   const {data, code} = await post(ENDPOINT, JSON.stringify({userInput, sessionToken: '00000000-1111-2222-3333-000000000001'}), header);
 //   console.log(data, code);
-// })
+// });
 
 test('/v1/location POST invalid sessionToken', async () => {
   const userInput = 'Ки';

--- a/test/v1/profile/saveUserDetailsController.spec.js
+++ b/test/v1/profile/saveUserDetailsController.spec.js
@@ -43,7 +43,7 @@ test('/v1/user', async () => {
 
   const {data: {user: userWithoutRole}} = await get(ENDPOINT, header);
   expect(userWithoutRole.fullName).toBe(fullName);
-  expect(userWithoutRole.role).toBe(null);
+  expect(userWithoutRole.role).toBeUndefined();
   expect(userWithoutRole.about).toBe(about);
   expect(userWithoutRole.imagePath).toBe(imagePath);
 });
@@ -97,6 +97,23 @@ test('/v1/user update busy', async () => {
     expect(code).toEqual(200);
     const {data: {user: current}} = await get(ENDPOINT, header);
     expect(current.busy).toEqual(user.busy);
+    return current;
+  }
+});
+
+test('/v1/user update placeId', async () => {
+  const header = getAuthHeader({id: '00000000-1111-2222-3333-000000000019', fullName: 'placeIdTest'});
+  let {data: {user}} = await get(ENDPOINT, header);
+  user = await updatePlaceId(user, 'anotherId');
+  user = await updatePlaceId(user, undefined);
+  await updatePlaceId(user, 'placeid');
+
+  async function updatePlaceId(user, value) {
+    user.placeId = value;
+    const {code} = await put(ENDPOINT, JSON.stringify(user), header);
+    expect(code).toEqual(200);
+    const {data: {user: current}} = await get(ENDPOINT, header);
+    expect(current.placeId).toEqual(value);
     return current;
   }
 });


### PR DESCRIPTION
- GET /v1/user возвращает дополнительно placeId,
- PUT /v1/user позволяет установить не только location, но и placeId
- POST /v1/location при указанном sessionToken, возвращает
{
  location: {description: string, placeId: string}[]
}

Это breaking change, до этого возвращался массив строк с description.
Frontend все еще не использует это API, так что можно пошалить.