### PR TITLE
feat: /v1/search поиск с поддержкой И

### DIFF
--- a/migrations/20201018003526_user_search_index.js
+++ b/migrations/20201018003526_user_search_index.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = async knex => {
+  await knex.raw('CREATE INDEX user_skills_index on "User" USING GIN (skills)');
+  await knex.raw('CREATE INDEX user_place_id_index on "User"(place_id)');
+  // we do not need a separate index on boolean busy flag - such index will be ignored by Postgres,
+  // random IO required for working with index is slower than sequenced read and check for flag.
+  await knex.raw('CREATE INDEX search_word_word_index ON search_word USING GIST (word gist_trgm_ops)');
+};
+
+exports.down = async knex => {
+  await knex.raw('DROP INDEX search_word_word_index');
+  await knex.raw('DROP INDEX user_place_id_index');
+  await knex.raw('DROP INDEX user_skills_index');
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,7 @@ import {accessTokenHandler} from './accessTokenHandler';
 import requestIdHandler from './requestId';
 import cors from 'cors';
 import {UserController, UsersController, AddUsersForTest, DelUsersForTest, addFakeUsers, getUsersCount} from './controllers/usersController';
-import {InvalidateSearchIndexController, InvalidateSearchIndexForTest} from './search';
+import {InvalidateSearchIndexController, InvalidateSearchIndexForTest, SearchController} from './search';
 
 const config = require('../config.js');
 
@@ -73,6 +73,7 @@ register(app, '/v1/users/:id', UsersController, true);
 register(app, '/v1/user', UserController, true);
 register(app, '/v1/profile/uploadImage', UploadImageController, true);
 register(app, '/v1/profile/search/', ProfileController, true);
+register(app, '/v1/search', SearchController, true);
 register(app, '/v1/location/', LocationsController, true);
 register(app, '/v1/contact/:contactId', SingleContactController, true);
 register(app, '/v1/contact', AllContactsController, true);

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -172,7 +172,7 @@ if (enableMethodsForTest) {
     const columns = Object.keys(newUsers[0]);
     await knex.raw(`INSERT INTO "User"(${Array(columns.length).fill('??').join(',')}) VALUES ${Array(newUsers.length).fill('(' + (Array(columns.length).fill('?').join(',') + ')')).join(',')} ON CONFLICT DO NOTHING`,
         [...columns, ...newUsers.map(user => Object.values(user)).flat()]);
-    await Promise.allSettled(newUsers.map(user => user.id ? invalidateSearchIndex(user.id) : void 0));
+    await Promise.allSettled(newUsers.map(user => (user.id ? invalidateSearchIndex(user.id) : void 0)));
     return newUsers;
   };
 

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -219,6 +219,19 @@
       "required":["about","location","fullName"]
     },
     {
+      "$id": "#POST>/v1/search",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "q": { "type": "string", "default": "", "maxLength": 32 },
+        "placeId": { "type": "string", "maxLength": 64 },
+        "skills": { "type": "array", "items": { "type": "string", "isStringNotEmpty": true, "maxLength": 32 }, "default": [] },
+        "busy": { "type": "boolean" },
+        "isFriend": { "type": "boolean" },
+        "offset": { "type": "integer", "minimum": 0, "default": 0 },
+        "count": { "type": "integer", "minimum": 1, "maximum": 1000, "default": 10 }
+      }
+    },
+    {
       "$id": "#GET>/v1/contact",
       "allOf": [{ "$ref": "#RequestBase" }]
     },

--- a/test/utils.js
+++ b/test/utils.js
@@ -29,6 +29,8 @@ function fetch(url, method, body, header = {'X-Request-Id': 'd5ab3356-f4b4-11ea-
   debug('<', url, method, body, header);
   let requestFinished;
   const requestPromise = new Promise(resolve => requestFinished = resolve);
+  if (body && typeof body !== 'string')
+    body = JSON.stringify(body);
   const req = (url.startsWith('https:') ? https : http).request(url, { method: method, headers: { 'Content-Type': 'application/json', ...header} }, res => {
     res.setEncoding('utf8');
     let data = '';

--- a/test/v1/searchController.spec.js
+++ b/test/v1/searchController.spec.js
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { post, getHost, getAuthHeader, genUsers } = require('../utils.js');
+
+function toExpected(user, isFriend = false) {
+  return {
+    about: user.about,
+    fullName: user.fullName,
+    id: user.id,
+    imagePath: user.imagePath,
+    location: user.location,
+    placeId: user.place_id,
+    skills: user.skills,
+    username: user.username,
+    busy: user.busy,
+    isFriend
+  };
+}
+
+describe.only('/v1/search2', () => {
+  let authHeader = null;
+  const endpoint = getHost() + '/v1/search';
+  const postSearch = body => post(endpoint, body, authHeader);
+  beforeEach(async () => {
+    const [current] = await genUsers(1602998724702, [{}]);
+    authHeader = getAuthHeader(current);
+  });
+  test('/v1/search busy', async () => {
+    const [freeUser, busyUser] = await genUsers(1603000265435, [{ busy: false }, { busy: true }]);
+    expect(await postSearch({ busy: false, count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.arrayContaining([toExpected(freeUser)]) } });
+    expect(await postSearch({ busy: true, count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.arrayContaining([toExpected(busyUser)]) } });
+  });
+  test('/v1/search placeId', async () => {
+    const [user] = await genUsers(1603000265435, [{ place_id: 'myPlaceId' }]);
+    expect(await postSearch({ placeId: 'myPlaceId', count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(user)] } });
+  });
+  test('/v1/search skills', async () => {
+    const [user] = await genUsers(1603000265435, [{ skills: [ 'mySkillA', 'mySkillB', 'mySkillC' ] }]);
+    expect(await postSearch({ skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(user)] } });
+    expect(await postSearch({ skills: ['mySkillB'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(user)] } });
+    expect(await postSearch({ skills: ['mySkillC'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(user)] } });
+    expect(await postSearch({ skills: ['mySkillA', 'mySkillC'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(user)] } });
+    expect(await postSearch({ skills: ['mySkillA', 'mySkillB', 'mySkillC'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(user)] } });
+    expect(await postSearch({ skills: ['abcdef'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ skills: ['mySkillA', 'mySkillB', 'abcdef'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+  });
+  test('/v1/search busy + placeId', async () => {
+    const [user] = await genUsers(1603000265435, [{ place_id: 'myPlaceId', busy: true }]);
+    expect(await postSearch({ busy: true, placeId: 'myPlaceId', count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ busy: false, placeId: 'myPlaceId', count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ busy: true, placeId: 'myPlaceIdA', count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+  });
+  test('/v1/search busy + skills', async () => {
+    const [user] = await genUsers(1603000265435, [{ busy: false, skills: ['mySkillA'] }]);
+    expect(await postSearch({ busy: false, skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ busy: true, skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ busy: false, skills: ['mySkillB'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+  });
+  test('/v1/search placeId + skills', async () => {
+    const [user] = await genUsers(1603000265435, [{ place_id: 'myPlaceId', skills: ['mySkillA'] }]);
+    expect(await postSearch({ placeId: 'myPlaceId', skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ placeId: 'myPlaceIdA', skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ placeId: 'myPlaceId', skills: ['mySkillB'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+  });
+  test('/v1/search busy + placeId + skills', async () => {
+    const [user] = await genUsers(1603000265435, [{ busy: true, place_id: 'myPlaceId', skills: ['mySkillA'] }]);
+    expect(await postSearch({ busy: true, placeId: 'myPlaceId', skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ busy: false, placeId: 'myPlaceId', skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ busy: true, placeId: 'myPlaceIdA', skills: ['mySkillA'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+    expect(await postSearch({ busy: true, placeId: 'myPlaceId', skills: ['mySkillB'], count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: expect.not.arrayContaining([toExpected(user)]) } });
+  });
+  test('/v1/search pagination', async () => {
+    const uniqueSkill = 'mySkillD' + Date.now();
+    const users = await genUsers(1603000265435, Array(5).fill({skills: [uniqueSkill]}));
+    const actual = [];
+    for (let offset = 0; offset < users.length; ++offset) {
+      const { data, code } = await postSearch({ skills: [uniqueSkill], count: 1, offset });
+      expect(code).toBe(200);
+      expect(data.total).toBe(5);
+      actual.push(...data.data);
+    }
+    const idOrder = (a,b) => a.id.localeCompare(b.id);
+    expect(users.map(user => toExpected(user)).sort(idOrder)).toStrictEqual(actual.sort(idOrder));
+    expect(await postSearch({ skills: [uniqueSkill], count: 1, offset: 6 }))
+        .toMatchObject({ code: 200, data: { data: [], total: 5 } });
+  });
+  test('/v1/search q', async () => {
+    const uniqueWord = 'myUniqueWordHm';
+    const uniquePlaceId = 'myPlaceId';
+    const uniqueSkill = 'jhsgflkewrjf';
+    const users = await genUsers(1603000265435, [{
+      fullName: uniqueWord,
+      place_id: uniquePlaceId,
+      busy: true,
+      skills: [],
+    },{
+      place_id: uniquePlaceId,
+      busy: false,
+      skills: [uniqueWord, uniqueSkill]
+    },{
+      location: uniqueWord,
+      place_id: uniquePlaceId,
+      busy: true,
+      skills: [uniqueSkill]
+    },{
+      about: uniqueWord,
+      place_id: uniquePlaceId,
+      busy: false,
+      skills: []
+    }]);
+    expect(await postSearch({ q: uniqueWord, placeId: uniquePlaceId, count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: users.map(user => toExpected(user)) } });
+    expect(await postSearch({ q: uniqueWord, busy: true, placeId: uniquePlaceId, count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(users[0]), toExpected(users[2])] } });
+    expect(await postSearch({ q: uniqueWord, busy: false, placeId: uniquePlaceId, count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(users[1]), toExpected(users[3])] } });
+    expect(await postSearch({ q: uniqueWord, busy: false, skills: [uniqueSkill], placeId: uniquePlaceId, count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(users[1])] } });
+    expect(await postSearch({ q: uniqueWord, busy: true, skills: [uniqueSkill], placeId: uniquePlaceId, count: 1000 }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(users[2])] } });
+  });
+  test('/v1/search empty', async () => {
+    await genUsers(1603000265435, Array(20).fill({}));
+    const {code, data: {data, total}} = await postSearch({});
+    expect(data.length).toBe(10);
+    expect(total).toBeGreaterThanOrEqual(20);
+    expect(code).toBe(200);
+  });
+  test('/v1/search count', async () => {
+    const pattern = {id: expect.any(String)};
+    await genUsers(1603000265435, Array(5).fill({}));
+    expect(await postSearch({ count: 3 }))
+        .toMatchObject({ code: 200, data: { data: Array(3).fill(pattern) } });
+    expect(await postSearch({ count: 1 }))
+        .toMatchObject({ code: 200, data: { data: Array(1).fill(pattern) } });
+    expect(await postSearch({ count: 5 }))
+        .toMatchObject({ code: 200, data: { data: Array(5).fill(pattern) } });
+  });
+  test('/v1/search not approved', async () => {
+    const uniqueSkill = 'mySkillD' + Date.now();
+    const [approved, ] = await genUsers(1603000265435, [{skills: [uniqueSkill]}, {skills: [uniqueSkill], status: 'awaiting'}]);
+    expect(await postSearch({ skills: [uniqueSkill] }))
+        .toMatchObject({ code: 200, data: { data: [toExpected(approved)], total: 1 } });
+  });
+  test('/v1/search isFriend', async () => {
+    const addFriend = friendId => post(`${getHost()}/v1/user/friend/${friendId}`, {}, authHeader).then(({code}) => expect(code).toBe(201));
+    const uniqueWord = 'myUniqueWordHm';
+    const place_id = 'myPlaceId';
+    const users = await genUsers(1603000265435, [{
+      fullName: uniqueWord,
+      place_id
+    },{
+      skills: [uniqueWord],
+      place_id
+    },{
+      location: uniqueWord,
+      place_id
+    },{
+      about: uniqueWord,
+      place_id
+    }]);
+    await addFriend(users[0].id);
+    await addFriend(users[2].id);
+    expect(await postSearch({ isFriend: true, q: uniqueWord, placeId: place_id}))
+        .toMatchObject({ code: 200, data: { data: [toExpected(users[0], true), toExpected(users[2], true)], total: 2 } });
+    expect(await postSearch({ isFriend: false, q: uniqueWord, placeId: place_id}))
+        .toMatchObject({ code: 200, data: { data: [toExpected(users[0], true), toExpected(users[1], false), toExpected(users[2], true), toExpected(users[3], false)], total: 4 } });
+  });
+  test('/v1/search 400', async () => {
+    expect(await post(endpoint, {})).toMatchObject({ code: 401 });
+    expect(await postSearch({ q: 'a'.repeat(33) })).toMatchObject({ code: 400 });
+    expect(await postSearch({ q: [] })).toMatchObject({ code: 400 });
+    expect(await postSearch({ q: {} })).toMatchObject({ code: 400 });
+    expect(await postSearch({ placeId: 'a'.repeat(65) })).toMatchObject({ code: 400 });
+    expect(await postSearch({ skills: 'abc' })).toMatchObject({ code: 400 });
+    expect(await postSearch({ skills: [[]] })).toMatchObject({ code: 400 });
+    expect(await postSearch({ skills: [''] })).toMatchObject({ code: 400 });
+    expect(await postSearch({ skills: ['a'.repeat(33)] })).toMatchObject({ code: 400 });
+    expect(await postSearch({ count: 2.5 })).toMatchObject({ code: 400 });
+    expect(await postSearch({ count: 0 })).toMatchObject({ code: 400 });
+    expect(await postSearch({ count: 1001 })).toMatchObject({ code: 400 });
+    expect(await postSearch({ offset: 2.5 })).toMatchObject({ code: 400 });
+    expect(await postSearch({ offset: -1 })).toMatchObject({ code: 400 });
+    expect(await postSearch({ busy: 'abc' })).toMatchObject({ code: 400 });
+    expect(await postSearch({ busy: 10 })).toMatchObject({ code: 400 });
+    expect(await postSearch({ isFriend: 'abc' })).toMatchObject({ code: 400 });
+    expect(await postSearch({ isFriend: 10 })).toMatchObject({ code: 400 });
+  });
+});


### PR DESCRIPTION
После того, как фронтенд смигрирует на этот метод - /v1/profile/search
будет прибит.

POST /v1/search параметры:
- q - строка, максимальная длина - 32, по умолчанию - '',
- placeId - строка, максимальная длина - 64, по умолчанию - undefined,
- skills - массив строк, максимальная длина каждой - 64, по умолчанию - [],
- busy - true/false, по умолчанию - undefined,
- isFriend - true/false, по умолчанию - undefined,
- offset - integer, минимум 0, по умолчанию - 0,
- count - integer, минимум 1, максимум 1000, по умолчанию 10.

Логика работы поиска:
- бьъем строку q на части по пробелам, приводим к нижнему регистру,
  ищем каждое слово в индексе, используем OR между словами,
- если указаны placeId, skills, либо busy - возвращаем только пользователей
  с заданными параметрами.
- если указан isFriend - то возвращаем только избранных пользователей.

Формат результата:
{
  data: [
    {
      id: uuid,
      fullName: string,
      username: string,
      imagePath: string,
      location: string,
      placeId: string,
      about: string,
      skills: string[],
      busy: boolean,
      isFriend: boolean
    },
  ],
  total: integer
}

Комит добавляет необходимые индексы, чтобы ускорить поисковый запрос,
когда у нас будет чуть больше реальных пользователей - необходимо
будет померить еще раз и проверить, что нам не нужно еще индексов.