### PR TITLE
feat: GET /v1/peerboard/auth

### DIFF
--- a/config.js
+++ b/config.js
@@ -56,6 +56,7 @@ const lambdaConfig = {
     url: process.env.IMAGE_URL
   },
   googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY,
+  peerboardAuthToken: process.env.PEERBOARD_AUTH_TOKEN,
   corsOrigin: process.env.CORS_ORIGIN || 'https://app.mesto.co/',
   adminUserId: process.env.ADMIN_USER_ID,
   enableMethodsForTest: false,
@@ -104,6 +105,7 @@ const developmentConfig = {
     skipUploadToS3: true
   },
 
+  peerboardAuthToken: process.env.PEERBOARD_AUTH_TOKEN || 'peerboard-auth-token',
   corsOrigin: '*',
   adminUserId: '00000000-1111-2222-3333-000000000009',
   enableMethodsForTest: true,

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import {FriendEntryController} from './controllers/friendController';
 import {LocationsController} from './controllers/locationController';
 import {SingleContactController, AllContactsController} from './controllers/contactController';
 import {GetSkillsController, GetLocationsController} from './controllers/databaseController';
+import {PeerboardAuthController} from './controllers/peerboardController';
 
 import { errorHandler, notFoundHandler } from './errorHandler';
 import {accessTokenHandler} from './accessTokenHandler';
@@ -82,6 +83,7 @@ register(app, '/v1/contact', AllContactsController, true);
 register(app, '/v1/openland/sendCode', OpenlandGetCodeController, true);
 register(app, '/v1/openland/verifyCode', OpenlandVerifyCodeController, true);
 register(app, '/v1/openland/getUser', OpenlandGetUserController, true);
+register(app, '/v1/peerboard/auth', PeerboardAuthController, true);
 
 register(app, '/v1/database/getSkills', GetSkillsController, true);
 register(app, '/v1/database/getLocations', GetLocationsController, true);

--- a/src/controllers/peerboardController.ts
+++ b/src/controllers/peerboardController.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import jsonwebtoken from 'jsonwebtoken';
+
+import knex from '../knex';
+import { UserStatus } from '../enums/UserStatus';
+const { peerboardAuthToken } = require('../../config.js');
+
+const peerboardAuthControler = express.Router();
+peerboardAuthControler.route('/').get(async (request, response) => {
+  try {
+    const id = request.user!.id;
+    const result: { rows: {
+      email: string,
+      fullName: string,
+      imagePath: string|null,
+      about: string
+    }[] } = await knex.raw('SELECT email, "fullName", "imagePath", about FROM "User" WHERE status = :status AND id = :id', { id, status: UserStatus.APPROVED });
+    const user = result.rows[0];
+    if (!user)
+      return response.status(404).send({}).end();
+    const payload = {
+      creds: {
+        v: 'v1',
+        fields: {
+          user_id: id,
+          email: user.email,
+          name: user.fullName,
+          avatar_url: user.imagePath,
+          bio: user.about,
+          role: 'member'
+        }
+      }
+    };
+    const token = jsonwebtoken.sign(payload, peerboardAuthToken, { expiresIn: '60s' });
+    return response.status(200).send({token}).end();
+  } catch (e) {
+    console.debug('GET /v1/peerboard/auth', e);
+    return response.status(500).send({}).end();
+  }
+});
+
+export { peerboardAuthControler as PeerboardAuthController };

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -284,6 +284,10 @@
       }
     },
     {
+      "$id": "#GET>/v1/peerboard/auth",
+      "allOf": [{ "$ref": "#RequestBase" }]
+    },
+    {
       "$id": "#POST>/v1/admin/addUsersForTest",
       "allOf": [{ "$ref": "#RequestBase" }],
       "type": "object"

--- a/test/v1/peerboardController.spec.js
+++ b/test/v1/peerboardController.spec.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const jsonwebtoken = require('jsonwebtoken');
+
+const { get, getAuthHeader, getHost, genUsers } = require('../utils.js');
+const { peerboardAuthToken } = require('../../config.js');
+
+describe('/v1/peerboard', () => {
+  const auth = authHeader => get(getHost() + '/v1/peerboard/auth', authHeader);
+  test('/v1/peerboard/auth', async () => {
+    expect(await auth()).toMatchObject({ code: 401 });
+
+    const [user] = await genUsers(1603094014186, [{}]);
+    const authHeader = getAuthHeader(user);
+    const result = await auth(authHeader);
+    expect(result).toMatchObject({ code: 200, data: { token: expect.any(String) }});
+    await new Promise(resolve => jsonwebtoken.verify(result.data.token, peerboardAuthToken, async (err, decoded) => {
+      expect(err).toBeNull();
+      expect(decoded).toMatchObject({
+        creds: {
+          v: 'v1',
+          fields: {
+            user_id: user.id,
+            email: user.email,
+            name: user.fullName,
+            avatar_url: user.imagePath,
+            bio: user.about,
+            role: 'member'
+          }
+        }
+      });
+      resolve();
+    }));
+  });
+});


### PR DESCRIPTION
Метод использует PEERBOARD_AUTH_TOKEN, для подписи и возврата
необходимых данных пользователя.
Метод доступен только авторизированным пользователям.