### PR TITLE
fix: v1/database/getSkills возвращает навыки, если они включают query

### DIFF
--- a/src/controllers/databaseController.ts
+++ b/src/controllers/databaseController.ts
@@ -26,12 +26,12 @@ getSkills.route('/')
         const {rows}: {rows: {skill: string}[]} = await knex.raw(`
           SELECT s.skill as skill FROM
           (SELECT lower(unnest(skills)) as skill FROM "User") s
-          GROUP BY s.skill HAVING s.skill ilike concat(?::text, '%')
+          GROUP BY s.skill HAVING s.skill ilike concat('%', ?::text, '%')
           LIMIT ? OFFSET ?`, [q, count, offset]);
         const {rows: [{count: total}]}: {rows: {count: string}[]} = await knex.raw(`
           SELECT COUNT(DISTINCT skill)
           FROM (SELECT LOWER(unnest(skills)) as skill FROM "User") s
-          WHERE skill ilike concat(?::text, '%')`, [q]);
+          WHERE skill ilike concat('%', ?::text, '%')`, [q]);
         response.status(200).send({
           count: parseInt(total, 10),
           items: rows.map(row => row.skill)

--- a/test/v1/databaseController.spec.js
+++ b/test/v1/databaseController.spec.js
@@ -30,6 +30,7 @@ test('GET /v1/database/getSkills', async () => {
   await check('test_skill', 0, 100, 200, 5, ['test_skilla', 'test_skillab', 'test_skillb', 'test_skillc', 'test_skillмощь']);
   await check('TeSt_SkIlL', 0, 100, 200, 5, ['test_skilla', 'test_skillab', 'test_skillb', 'test_skillc', 'test_skillмощь']);
   await check('test_skill', 0, 1000, 200, 5, ['test_skilla', 'test_skillab', 'test_skillb', 'test_skillc', 'test_skillмощь']);
+  await check('est_skill', 0, 1000, 200, 5, ['test_skilla', 'test_skillab', 'test_skillb', 'test_skillc', 'test_skillмощь']);
   await check('test_skill', 0, 1, 200, 5, ['test_skilla']);
   await check('test_skill', 1, 1, 200, 5, ['test_skillab']);
   await check('test_skill', 2, 1, 200, 5, ['test_skillb']);


### PR DESCRIPTION
До этого возвращались только навыки, для которых q - префикс.