### PR TITLE
feat: поиск по стране

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -256,7 +256,7 @@ searchController.route('/').post(async (request, response) => {
       (partEntries.length ? `(sw.word LIKE CONCAT(:part${partEntries.length - 1}::text, '%'))` : '')
     ].filter(v => v.length > 0).join(' OR ');
     const userWhereClause = ' u.status = :userStatus ' +
-      (placeId ? ' AND u.place_id = :placeId' : '') +
+      (placeId ? ' AND u.place_id LIKE CONCAT(:placeId::text, \'%\')' : '') +
       (skills.length ? ' AND u.skills_lo && :skills ' : '') +
       (busy !== undefined ? ' AND u.busy = :busy' : '');
     const result = await knex.raw(`


### PR DESCRIPTION
placeId, который возвращает API теперь состоит из двух частей:
countryCode|placeId|

Если у пользователя указана только страна, то "ru|", если город,
то "ru|someId|", если что-то странное без страны то "|someId|".

Если в поиске вбита только страна, то мы ищем всех пользователей,
который начинаются с placeId этой страны, т.е. "ru|" и "ru|someId|"
подойдут. Если вбит город, то ищем по полному совпадению.

| в конце необходимо на тот случай если один placeId в google maps
является префиксом другого placeId