### PR TITLE
feat(permissions): добавлена базовая поддержка permissions

### DIFF
--- a/migrations/20201223220704_permission.js
+++ b/migrations/20201223220704_permission.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = async function(knex) {
+  await knex.raw(`CREATE TABLE permission (
+        id integer PRIMARY KEY,
+        description varchar(128) NOT NULL CHECK (description <> '')
+    )`);
+  await knex.raw(`CREATE TABLE user_permission (
+        user_id uuid references "User"(id),
+        permission_id integer references permission(id)
+    )`);
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (1, 'Allow to add any permission to any user')`);
+};
+
+exports.down = async function(knex) {
+  await knex.raw('DROP TABLE user_permission');
+  await knex.raw('DROP TABLE permission');
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import {LocationsController,PlaceIdResolverController} from './controllers/locat
 import {SingleContactController, AllContactsController} from './controllers/contactController';
 import {GetSkillsController, GetLocationsController} from './controllers/databaseController';
 import {PeerboardAuthController} from './controllers/peerboardController';
+import {addPermission, delPermission} from './controllers/permissionController';
 
 import { errorHandler, notFoundHandler } from './errorHandler';
 import {accessTokenHandler} from './accessTokenHandler';
@@ -89,6 +90,8 @@ register(app, '/v1/openland/sendCode', OpenlandGetCodeController, true);
 register(app, '/v1/openland/verifyCode', OpenlandVerifyCodeController, true);
 register(app, '/v1/openland/getUser', OpenlandGetUserController, true);
 register(app, '/v1/peerboard/auth', PeerboardAuthController, true);
+register(app, '/v1/addPermission', addPermission, true);
+register(app, '/v1/delPermission', delPermission, true);
 
 register(app, '/v1/database/getSkills', GetSkillsController, true);
 register(app, '/v1/database/getLocations', GetLocationsController, true);

--- a/src/controllers/permissionController.ts
+++ b/src/controllers/permissionController.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { Permission } from '../enums/permission';
+import knex from '../knex';
+import { getArgs } from '../utils';
+
+const addPermission = express.Router();
+addPermission.route('/').post(async (request, response) => {
+  try {
+    const {permissions} = request.user!;
+    if (!permissions || !permissions.includes(Permission.ADDDELPERMISSION))
+      return response.status(401).json({}).end();
+    const {permission_id, user_id} = getArgs(request);
+    if (!Object.values(Permission).includes(permission_id))
+      return response.status(400).json({}).end();
+    await knex.raw('INSERT INTO user_permission(user_id, permission_id) VALUES (?, ?)', [user_id, permission_id]);
+    return response.status(200).json({}).end();
+  } catch (e) {
+    console.debug('POST user/addPermission error', e);
+    response.status(500).json({}).end();
+  }
+});
+
+const delPermission = express.Router();
+delPermission.route('/').post(async (request, response) => {
+  try {
+    const {permissions} = request.user!;
+    if (!permissions || !permissions.includes(Permission.ADDDELPERMISSION))
+      return response.status(401).json({}).end();
+    const {permission_id, user_id} = getArgs(request);
+    if (!Object.values(Permission).includes(permission_id))
+      return response.status(400).json({}).end();
+    await knex.raw('DELETE FROM user_permission WHERE user_id = ? AND permission_id = ?', [user_id, permission_id]);
+    return response.status(200).json({}).end();
+  } catch (e) {
+    console.debug('POST user/delPermission error', e);
+    response.status(500).json({}).end();
+  }
+});
+
+export {
+  addPermission,
+  delPermission
+};

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -205,6 +205,7 @@ if (enableMethodsForTest) {
       .post(async (request, response) => {
         const {userIds}: {userIds: string[]} = getArgs(request);
         // TODO(ak239): ON DELETE CASCADE
+        await knex.raw(`DELETE FROM user_permission WHERE user_id IN (${Array(userIds.length).fill('?').join(',')})`, userIds);
         await knex.raw(`DELETE FROM search_word_user WHERE user_id IN (${Array(userIds.length).fill('?').join(',')})`, userIds);
         await knex.raw(`DELETE FROM "Friend" WHERE "userId" IN (${Array(userIds.length).fill('?').join(',')}) OR "friendId" IN (${Array(userIds.length).fill('?').join(',')})`, [...userIds, ...userIds]);
         await knex.raw(`DELETE FROM "UserToken" WHERE "userId" IN (${Array(userIds.length).fill('?').join(',')})`, userIds);

--- a/src/enums/permission.ts
+++ b/src/enums/permission.ts
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-class UserModel {
-  id!: string;
-  fullName!: string;
-  permissions!: number[];
+enum Permission {
+    ADDDELPERMISSION = 1,
 }
 
-export { UserModel };
+export { Permission };

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -354,5 +354,23 @@
       "properties": {
         "placeId": { "type": "string", "maxLength": 256 }
       }
+    },
+    {
+      "$id": "#POST>/v1/addPermission",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "user_id": { "type": "string", "format": "uuid" },
+        "permission_id": { "type": "integer" }
+      },
+      "required": [ "user_id", "permission_id" ]
+    },
+    {
+      "$id": "#POST>/v1/delPermission",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "user_id": { "type": "string", "format": "uuid" },
+        "permission_id": { "type": "integer" }
+      },
+      "required": [ "user_id", "permission_id" ]
     }
 ]

--- a/test/v1/adminControllerForTest.spec.js
+++ b/test/v1/adminControllerForTest.spec.js
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * Copyright (c) Mesto.co
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 const { post, getHost, genUsers, delUsers } = require('../utils.js');
 
 test('POST /v1/admin/(add|del)UsersForTest', async () => {

--- a/test/v1/permissionController.spec.js
+++ b/test/v1/permissionController.spec.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { getAuthHeader, getHost, genUsers, post } = require('../utils.js');
+
+describe('/v1/permission', () => {
+  test('/v1/addDelPermission with proper auth', async () => {
+    const [rootUser, aUser] = await genUsers(1609178164580, [{}, {}]);
+    const authHeader = getAuthHeader({
+      user: rootUser,
+      permissions: [1]
+    });
+    expect(await post(getHost() + '/v1/addPermission', {user_id: aUser.id, permission_id: 1}, authHeader))
+        .toMatchObject({ code: 200 });
+    expect(await post(getHost() + '/v1/delPermission', {user_id: aUser.id, permission_id: 1}, authHeader))
+        .toMatchObject({ code: 200 });
+  });
+  test('/v1/addDelPermission without proper auth', async () => {
+    const [rootUser, aUser] = await genUsers(1609178164580, [{}, {}]);
+    const authHeader = getAuthHeader({
+      user: rootUser
+    });
+    expect(await post(getHost() + '/v1/addPermission', {user_id: aUser.id, permission_id: 1}, authHeader))
+        .toMatchObject({ code: 401 });
+    expect(await post(getHost() + '/v1/delPermission', {user_id: aUser.id, permission_id: 1}, authHeader))
+        .toMatchObject({ code: 401 });
+  });
+});


### PR DESCRIPTION
Для начала добавлен максимально простой вариант:
- справочник со всеми возможными разрешениями - permission,
- связь между пользователем и разрешением - user_permission,
- access_token дополнительно содержит массив разрешеий,
- каждый метод может проверять разрешение при необходимости.

Пока что добавлено только одно разрешение - разрешение добавлять
либо удалять разрешения.