### PR TITLE
feat: добавлены методы для работы с событиями

### DIFF
--- a/migrations/20210111184458_event.js
+++ b/migrations/20210111184458_event.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exports.up = async function(knex) {
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (2, 'Allow to activate user')`);
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (3, 'Allow to ban user')`);
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (4, 'Allow to add user')`);
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (5, 'Allow to send invite email')`);
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (6, 'Allow to exists users')`);
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (7, 'Allow to add/edit event')`);
+  await knex.raw(`INSERT INTO permission(id, description) VALUES (8, 'Allow to del event')`);
+
+  await knex.raw(`CREATE TYPE event_status_t as enum('created', 'deleted');`);
+  await knex.raw(`CREATE TABLE event (
+        id UUID NOT NULL PRIMARY KEY DEFAULT uuid_generate_v4(),
+        creator uuid references "User"(id),
+        time TIMESTAMP NOT NULL,
+        title varchar(128) NOT NULL CHECK (title <> ''),
+        description varchar(4096) NOT NULL CHECK (description <> ''),
+        image varchar(256) NULL,
+        link varchar(256) NOT NULL CHECK (link <> ''),
+        status event_status_t
+    )`);
+  await knex.raw(`CREATE TABLE event_user (
+        user_id uuid references "User"(id),
+        event_id uuid references event(id)
+    )`);
+  await knex.raw('CREATE INDEX event_user_user_id_index on event_user(user_id)');
+  await knex.raw('CREATE INDEX event_user_event_id_index on event_user(event_id)');
+};
+
+exports.down = async function(knex) {
+  await knex.raw('DROP INDEX event_user_user_id_index');
+  await knex.raw('DROP INDEX event_user_event_id_index');
+  await knex.raw('DROP TABLE event_user');
+  await knex.raw('DROP TABLE event');
+
+  await knex.raw('DELETE FROM permission WHERE id IN (2, 3, 4, 5, 6, 7, 8)');
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,7 @@ import cors from 'cors';
 import {UserController, UsersController, AddUsersForTest, DelUsersForTest, addFakeUsers, getUsersCount, printSomeUsers, addUser, activateUser, banUser, existUsers} from './controllers/usersController';
 import {InvalidateSearchIndexController, InvalidateSearchIndexForTest, SearchController} from './search';
 import { OpenlandGetCodeController, OpenlandGetUserController, OpenlandVerifyCodeController, OpenlandSetNextCodeForTest } from './controllers/openlandController';
+import { addEvent, delEvent, editEvent, getEvent, joinEvent, unjoinEvent } from './controllers/eventController';
 
 const config = require('../config.js');
 
@@ -92,6 +93,13 @@ register(app, '/v1/openland/getUser', OpenlandGetUserController, true);
 register(app, '/v1/peerboard/auth', PeerboardAuthController, true);
 register(app, '/v1/addPermission', addPermission, true);
 register(app, '/v1/delPermission', delPermission, true);
+
+register(app, '/v1/event/addEvent', addEvent, true);
+register(app, '/v1/event/getEvent', getEvent, true);
+register(app, '/v1/event/editEvent', editEvent, true);
+register(app, '/v1/event/delEvent', delEvent, true);
+register(app, '/v1/event/joinEvent', joinEvent, true);
+register(app, '/v1/event/unjoinEvent', unjoinEvent, true);
 
 register(app, '/v1/admin/addUser', addUser, true);
 register(app, '/v1/admin/activateUser', activateUser, true);

--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { Permission } from '../enums/permission';
+import knex from '../knex';
+import { getArgs, hasPermission } from '../utils';
+
+enum EventStatus {
+    CREATED = 'created',
+    DELETED = 'deleted',
+}
+
+const getEvent = express.Router();
+getEvent.route('/').get(async (request, response) => {
+  try {
+    const {id} = getArgs(request);
+    const currentUser = request.user!.id;
+    const {rows: rowsJoin} = await knex.raw('SELECT 1 FROM event_user WHERE event_id = :id AND user_id = :currentUser', { id, currentUser });
+    const joined = rowsJoin.length > 0;
+    const {rows: [eventRow]} = await knex.raw(`SELECT creator, time, title, description, image, link FROM event WHERE id = :id AND status = :status`, { id, status: EventStatus.CREATED });
+    if (!eventRow)
+      return response.status(404).json({}).end();
+    let result = {
+      creator: eventRow.creator,
+      time: eventRow.time,
+      title: eventRow.title,
+      description: eventRow.description
+    };
+    if (eventRow.image)
+      result = Object.assign(result, {image: eventRow.image});
+    if (joined || eventRow.creator === currentUser)
+      result = Object.assign(result, {link: eventRow.link});
+    return response.status(200).json(result).end();
+  } catch (e) {
+    console.debug('POST event/get error', e);
+    response.status(500).json({}).end();
+  }
+});
+
+const addEvent = express.Router();
+addEvent.route('/').post(async (request, response) => {
+  try {
+    if (!hasPermission(request, Permission.EVENT))
+      return response.status(401).json({}).end();
+    const creator = request.user!.id;
+    const {time, title, description, image, link} = getArgs(request);
+    const {rows: [{id}]} = await knex.raw('INSERT INTO event(creator, time, title, description, image, link, status) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id', [creator, time, title, description, image || null, link, EventStatus.CREATED]);
+    return response.status(200).json({id}).end();
+  } catch (e) {
+    // invalid_datetime_format
+    if (e.code === '22007')
+      return response.status(400).json({message: 'Invalid time format'}).end();
+    if (e.code === '23514')
+      return response.status(400).json({message: 'Invalid creator'}).end();
+    console.debug('POST event/add error', e);
+    return response.status(500).json({}).end();
+  }
+});
+
+const editEvent = express.Router();
+editEvent.route('/').post(async (request, response) => {
+  try {
+    if (!hasPermission(request, Permission.EVENT))
+      return response.status(401).json({}).end();
+    const currentUser = request.user!.id;
+    const {id, title, time, description, image, link} = getArgs(request);
+    const {rowCount} = await knex.raw('UPDATE event SET title = :title, description = :description, image = :image, link = :link, time = :time WHERE id = :id AND creator = :currentUser AND status = :status', {
+      title,
+      description,
+      image: image || null,
+      time,
+      link,
+      id,
+      currentUser,
+      status: EventStatus.CREATED
+    });
+    if (rowCount < 1)
+      return response.status(404).json({}).end();
+    return response.status(200).json({}).end();
+  } catch (e) {
+    // invalid_datetime_format
+    if (e.code === '22007')
+      return response.status(400).json({message: 'Invalide time format'}).end();
+    if (e.code === '23514')
+      return response.status(400).json({message: 'Invalid creator'}).end();
+    console.debug('POST event/edit', e);
+    return response.status(500).json({}).end();
+  }
+});
+
+const delEvent = express.Router();
+delEvent.route('/').post(async (request, response) => {
+  try {
+    const {id} = getArgs(request);
+    if (!hasPermission(request, Permission.DELEVENT)) {
+      const currentUser = request.user!.id;
+      const {rows} = await knex.raw('SELECT 1 FROM event WHERE id = :id AND creator = :currentUser', {id, currentUser});
+      if (rows.length === 0)
+        return response.status(401).json({}).end();
+    }
+    await knex.raw('UPDATE event SET status = :status WHERE id = :id', { id, status: EventStatus.DELETED });
+    return response.status(200).json({}).end();
+  } catch (e) {
+    console.debug('POST event/del', e);
+    response.status(500).json({}).end();
+  }
+});
+
+const joinEvent = express.Router();
+joinEvent.route('/').post(async (request, response) => {
+  try {
+    const {id} = getArgs(request);
+    await knex.raw('INSERT INTO event_user(user_id, event_id) VALUES (:userId, :id)', {
+      userId: request.user!.id,
+      id
+    });
+    return response.status(200).json({}).end();
+  } catch (e) {
+    // FOREIGN KEY VIOLATION
+    if (e.code === '23503')
+      return response.status(404).json({message: 'User or event was not found'}).end();
+    console.debug('POST event/join', e);
+    return response.status(500).json({}).end();
+  }
+});
+
+const unjoinEvent = express.Router();
+unjoinEvent.route('/').post(async (request, response) => {
+  try {
+    const {id} = getArgs(request);
+    await knex.raw('DELETE FROM event_user WHERE user_id = :userId AND event_id = :id', {
+      userId: request.user!.id,
+      id
+    });
+    return response.status(200).json({}).end();
+  } catch (e) {
+    console.debug('POST event/unjoin', e);
+    return response.status(500).json({}).end();
+  }
+});
+
+export { getEvent, addEvent, delEvent, editEvent, joinEvent, unjoinEvent };

--- a/src/enums/permission.ts
+++ b/src/enums/permission.ts
@@ -19,7 +19,9 @@ enum Permission {
     BANUSER = 3,
     ADDUSER = 4,
     SENDINVITEEMAIL = 5,
-    NEWUSERS = 6
+    NEWUSERS = 6,
+    EVENT = 7,
+    DELEVENT = 8
 }
 
 export { Permission };

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -422,5 +422,62 @@
         "emails": { "type": "array", "items": { "type": "string", "format": "email" }}
       },
       "required": [ "emails" ]
+    },
+    {
+      "$id": "#POST>/v1/event/addEvent",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "time": { "type": "string", "maxLength": 32 },
+        "title": { "type": "string", "maxLength": 128, "minLength": 1 },
+        "description": { "type": "string", "maxLength": 4096, "minLength": 1 },
+        "image": { "type": "string", "format": "uri", "maxLength": 256 },
+        "link": { "type": "string", "format": "uri", "maxLength": 256, "minLength": 1 }
+      },
+      "required": [ "time", "title", "description", "link" ]
+    },
+    {
+      "$id": "#GET>/v1/event/getEvent",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" }
+      },
+      "required": [ "id" ]
+    },
+    {
+      "$id": "#POST>/v1/event/editEvent",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "time": { "type": "string", "maxLength": 32 },
+        "title": { "type": "string", "maxLength": 128 },
+        "description": { "type": "string", "maxLength": 4096 },
+        "image": { "type": "string", "format": "uri", "maxLength": 256 },
+        "link": { "type": "string", "format": "uri", "maxLength": 256 }
+      },
+      "required": [ "id", "time", "title", "description", "link" ]
+    },
+    {
+      "$id": "#POST>/v1/event/delEvent",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" }
+      },
+      "required": [ "id" ]
+    },
+    {
+      "$id": "#POST>/v1/event/joinEvent",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" }
+      },
+      "required": [ "id" ]
+    },
+    {
+      "$id": "#POST>/v1/event/unjoinEvent",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" }
+      },
+      "required": [ "id" ]
     }
 ]

--- a/test/v1/eventController.spec.js
+++ b/test/v1/eventController.spec.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) Mesto.co
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { getAuthHeader, getHost, genUsers, post, get } = require('../utils.js');
+
+test('/v1/event/addEvent', async () => {
+  const [user] = await genUsers(1610476835367, [{}]);
+  const authHeader = getAuthHeader({id: user.id, permissions: [7, 8]});
+  const addEvent = (data, header = authHeader) => post(getHost() + '/v1/event/addEvent', data, header);
+  const getEvent = id => get(getHost() + '/v1/event/getEvent?id=' + id, authHeader);
+  const delEvent = id => post(getHost() + '/v1/event/delEvent', {id}, authHeader);
+  const eventData = { time: new Date().toISOString(), title: 'event', description: 'description', link: 'https://youtube.com/abc'};
+  const result = await addEvent(eventData);
+  expect(await getEvent(result.data.id)).toMatchObject({
+    code: 200,
+    data: {time: eventData.time, title: eventData.title, description: eventData.description}
+  });
+  expect(await getEvent('d5ab3356-f4b4-11ea-adc1-0242ac120002')).toMatchObject({
+    code: 404
+  });
+  expect(result).toMatchObject({code: 200, data: { id: expect.any(String) }});
+  expect(await delEvent(result.data.id)).toMatchObject({code: 200});
+
+  expect(await addEvent({...eventData, time: undefined})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, time: 'not-a-time-string'})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, title: undefined})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, title: ''})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, title: 'a'.repeat(129)})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, description: undefined})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, description: ''})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, description: 'a'.repeat(4097)})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, link: undefined})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, link: 'a'.repeat(257)})).toMatchObject({code: 400});
+  expect(await addEvent({...eventData, link: 'a'.repeat(256)})).toMatchObject({code: 400});
+
+  const unauthorizedHeader = getAuthHeader({id: user.id});
+  expect(await addEvent(eventData, unauthorizedHeader)).toMatchObject({code: 401});
+});
+
+test('/v1/event/editEvent', async () => {
+  const [user, anotherUser] = await genUsers(1610519232069, [{}, {}]);
+  const authHeader = getAuthHeader({id: user.id, permissions: [7, 8]});
+  const anotherUserHeader = getAuthHeader({id: anotherUser.id, permissions: [7, 8]});
+
+  const addEvent = (data, header = authHeader) => post(getHost() + '/v1/event/addEvent', data, header);
+  const getEvent = id => get(getHost() + '/v1/event/getEvent?id=' + id, authHeader);
+  const editEvent = (id, data, header = authHeader) => post(getHost() + '/v1/event/editEvent', {...data, id}, header);
+  const delEvent = id => post(getHost() + '/v1/event/delEvent', {id}, authHeader);
+  const eventData = { time: new Date().toISOString(), title: 'event', description: 'description', link: 'https://youtube.com/abc'};
+  const {data: {id}} = await addEvent(eventData);
+
+  const withUpdatedTime = {...eventData, time: new Date().toISOString()};
+  expect(await editEvent(id, withUpdatedTime)).toMatchObject({code: 200});
+  expect(await getEvent(id)).toMatchObject({code: 200, data: withUpdatedTime});
+
+  const withUpdatedTitle = {...eventData, title: 'new-title'};
+  expect(await editEvent(id, withUpdatedTitle)).toMatchObject({code: 200});
+  expect(await getEvent(id)).toMatchObject({code: 200, data: withUpdatedTitle});
+
+  const withUpdatedDescription = {...eventData, description: 'new description'};
+  expect(await editEvent(id, withUpdatedDescription)).toMatchObject({code: 200});
+  expect(await getEvent(id)).toMatchObject({code: 200, data: withUpdatedDescription});
+
+  const withUpdatedLink = {...eventData, link: 'https://youtube.com/abc2'};
+  expect(await editEvent(id, withUpdatedLink)).toMatchObject({code: 200});
+  expect(await getEvent(id)).toMatchObject({code: 200, data: withUpdatedLink});
+
+  const withUpdatedImage = {...eventData, image: 'https://example.com/abc'};
+  expect(await editEvent(id, withUpdatedImage)).toMatchObject({code: 200});
+  expect(await getEvent(id)).toMatchObject({code: 200, data: withUpdatedImage});
+
+  expect(await editEvent('', {...eventData, time: undefined})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, time: undefined})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, time: 'not-a-time-string'})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, title: undefined})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, title: ''})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, title: 'a'.repeat(129)})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, description: undefined})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, description: 'a'.repeat(4097)})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, link: undefined})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, link: 'a'.repeat(257)})).toMatchObject({code: 400});
+  expect(await editEvent(id, {...eventData, link: 'a'.repeat(256)})).toMatchObject({code: 400});
+  expect(await editEvent('d5ab3356-f4b4-11ea-adc1-0242ac120002', eventData)).toMatchObject({code: 404});
+  expect(await editEvent(id, eventData, anotherUserHeader)).toMatchObject({code: 404});
+  const unauthorizedHeader = getAuthHeader({id: user.id});
+  expect(await editEvent(id, eventData, unauthorizedHeader)).toMatchObject({code: 401});
+  expect(await delEvent(id)).toMatchObject({code: 200});
+  expect(await editEvent(id, withUpdatedImage)).toMatchObject({code: 404});
+});
+
+test('/v1/event/delEvent', async () => {
+  const [user, anotherUser] = await genUsers(1610520856202, [{}, {}]);
+  const authHeader = getAuthHeader({id: user.id, permissions: [7]});
+  const anotherUserHeader = getAuthHeader({id: anotherUser.id, permissions: [8]});
+  const unauthorizedHeader = getAuthHeader({id: anotherUser.id});
+
+  const addEvent = (data, header = authHeader) => post(getHost() + '/v1/event/addEvent', data, header);
+  const delEvent = (id, header = authHeader) => post(getHost() + '/v1/event/delEvent', {id}, header);
+  const eventData = { time: new Date().toISOString(), title: 'event', description: 'description', link: 'https://youtube.com/abc'};
+  {
+    // user with special permission can remove any event
+    const {data: {id}} = await addEvent(eventData);
+    expect(await delEvent(id, anotherUserHeader)).toMatchObject({code: 200});
+  }
+  {
+    // can remove own event
+    const {data: {id}} = await addEvent(eventData);
+    expect(await delEvent(id, authHeader)).toMatchObject({code: 200});
+  }
+  {
+    const {data: {id}} = await addEvent(eventData);
+    expect(await delEvent(id, unauthorizedHeader)).toMatchObject({code: 401});
+    expect(await delEvent(id)).toMatchObject({code: 200});
+  }
+});
+
+test('/v1/event/joinEvent', async () => {
+  const [user, anotherUser] = await genUsers(1610520856202, [{}, {}]);
+  const authHeader = getAuthHeader({id: user.id, permissions: [7]});
+  const anotherUserHeader = getAuthHeader({id: anotherUser.id});
+  const addEvent = (data, header = authHeader) => post(getHost() + '/v1/event/addEvent', data, header);
+  const getEvent = (id, header = authHeader) => get(getHost() + '/v1/event/getEvent?id=' + id, header);
+  const joinEvent = (id, header = authHeader) => post(getHost() + '/v1/event/joinEvent', {id}, header);
+  const unjoinEvent = (id, header = authHeader) => post(getHost() + '/v1/event/unjoinEvent', {id}, header);
+  const delEvent = id => post(getHost() + '/v1/event/delEvent', {id}, authHeader);
+
+  const eventData = { time: new Date().toISOString(), title: 'event', description: 'description', link: 'https://youtube.com/abc'};
+  const {data: {id}} = await addEvent(eventData);
+
+  const withoutLink = {time: eventData.time, title: eventData.title, description: eventData.description};
+  expect(await getEvent(id)).toMatchObject({code: 200, data: eventData});
+  expect(await getEvent(id, anotherUserHeader)).toMatchObject({code: 200, data: withoutLink});
+  expect(await joinEvent(id, anotherUserHeader)).toMatchObject({code: 200});
+  expect(await getEvent(id, anotherUserHeader)).toMatchObject({code: 200, data: eventData});
+  expect(await unjoinEvent(id, anotherUserHeader)).toMatchObject({code: 200});
+  expect(await getEvent(id, anotherUserHeader)).toMatchObject({code: 200, data: withoutLink});
+
+  expect(await joinEvent('not-a-uuid', anotherUserHeader)).toMatchObject({code: 400});
+  expect(await joinEvent('d5ab3356-f4b4-11ea-adc1-0242ac120002', anotherUserHeader)).toMatchObject({code: 404});
+  expect(await unjoinEvent('not-a-uuid', anotherUserHeader)).toMatchObject({code: 400});
+  expect(await unjoinEvent('d5ab3356-f4b4-11ea-adc1-0242ac120002', anotherUserHeader)).toMatchObject({code: 200});
+
+  expect(await delEvent(id)).toMatchObject({code: 200});
+});


### PR DESCRIPTION
/v1/event/addEvent добавляет событие, доступно лишь пользователям
с разрешением Permission.EVENT
/v1/event/editEvent редактирует события, доступно пользователям с
Permission.EVENT и автором события,
/v1/event/joinEvent добавляет текущего пользователя в список идущих
/v1/event/unjoinEvent удаляет текущего пользователя из идущих
в api.json описаны все доступные параметры методов.