### PR TITLE
feat: добавлен /v1/event/search

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,7 @@ import cors from 'cors';
 import {UserController, UsersController, AddUsersForTest, DelUsersForTest, addFakeUsers, getUsersCount, printSomeUsers, addUser, activateUser, banUser, existUsers} from './controllers/usersController';
 import {InvalidateSearchIndexController, InvalidateSearchIndexForTest, SearchController} from './search';
 import { OpenlandGetCodeController, OpenlandGetUserController, OpenlandVerifyCodeController, OpenlandSetNextCodeForTest } from './controllers/openlandController';
-import { addEvent, delEvent, editEvent, getEvent, joinEvent, unjoinEvent } from './controllers/eventController';
+import { addEvent, delEvent, editEvent, getEvent, joinEvent, unjoinEvent, searchEvents } from './controllers/eventController';
 
 const config = require('../config.js');
 
@@ -100,6 +100,7 @@ register(app, '/v1/event/editEvent', editEvent, true);
 register(app, '/v1/event/delEvent', delEvent, true);
 register(app, '/v1/event/joinEvent', joinEvent, true);
 register(app, '/v1/event/unjoinEvent', unjoinEvent, true);
+register(app, '/v1/event/search', searchEvents, true);
 
 register(app, '/v1/admin/addUser', addUser, true);
 register(app, '/v1/admin/activateUser', activateUser, true);

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -207,8 +207,9 @@ if (enableMethodsForTest) {
       .post(async (request, response) => {
         const {userIds}: {userIds: string[]} = getArgs(request);
         // TODO(ak239): ON DELETE CASCADE
-        await knex.raw(`DELETE FROM event WHERE creator IN (${Array(userIds.length).fill('?').join(',')})`, userIds);
         await knex.raw(`DELETE FROM event_user WHERE user_id IN (${Array(userIds.length).fill('?').join(',')})`, userIds);
+        await knex.raw(`DELETE FROM event_user WHERE event_id IN (SELECT id FROM event WHERE creator IN (${Array(userIds.length).fill('?').join(',')}))`, userIds);
+        await knex.raw(`DELETE FROM event WHERE creator IN (${Array(userIds.length).fill('?').join(',')})`, userIds);
         await knex.raw(`DELETE FROM user_permission WHERE user_id IN (${Array(userIds.length).fill('?').join(',')})`, userIds);
         await knex.raw(`DELETE FROM search_word_user WHERE user_id IN (${Array(userIds.length).fill('?').join(',')})`, userIds);
         await knex.raw(`DELETE FROM "Friend" WHERE "userId" IN (${Array(userIds.length).fill('?').join(',')}) OR "friendId" IN (${Array(userIds.length).fill('?').join(',')})`, [...userIds, ...userIds]);

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -479,5 +479,18 @@
         "id": { "type": "string", "format": "uuid" }
       },
       "required": [ "id" ]
+    },
+    {
+      "$id": "#POST>/v1/event/search",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "createdByMe": { "type": "boolean", "default": false },
+        "joinedByMe": { "type": "boolean", "default": false },
+        "from": { "type": "string", "maxLength": 32 },
+        "to": { "type": "string", "maxLength": 32 },
+        "offset": { "type": "integer", "minimum": 0, "default": 0 },
+        "count": { "type": "integer", "minimum": 1, "maximum": 1000, "default": 10 }
+      },
+      "requred": [ "from", "to" ]
     }
 ]


### PR DESCRIPTION
Метод принимает следующие параметры:
- createdByMy - флаг, если true, то вернет только события, которые
  были созданы текущим пользователем,
- joinedByMe - флаг, если true, то вернет только события, к которым
  текущий пользователь присоединился,
- from и to - диапазон для которого необходимо вернуть события, обе
  границы включены,
- offest - смещение для пагинациия,
- count - количество записей для пагинации,

Все события отсортированы по времени, начиная от ближайшего к from.

Метод возвращает объект с полем data, которое содержит массив найденных
событий (link присутсвует только если текущий пользователь создал
найденное событие, либо присоединился к нему), и с полем total - общее
количество найденных событий без учета offset и count.