### PR TITLE
feat: added password related methods

### DIFF
--- a/config.js
+++ b/config.js
@@ -116,7 +116,8 @@ const developmentConfig = {
   adminUserId: '00000000-1111-2222-3333-000000000009',
   enableMethodsForTest: true,
   openlandToken: process.env.OPENLAND_TOKEN || 'YYeXUMHV_40G3jKvYV2Bz1wIfxpWUB9hfWbXmVkEormuC3jTT2ZqbUWOMw4LGtKxVhqmzA-7ds_Bp3MSXEeW5A',
-  openlandCodeSecret: process.env.OPENLAND_CODE_SECRET || '4003fe4c92ed4ac97363c7528e30bbb798c59fefbcfb35ffe6ef937c45d86d86'
+  openlandCodeSecret: process.env.OPENLAND_CODE_SECRET || '4003fe4c92ed4ac97363c7528e30bbb798c59fefbcfb35ffe6ef937c45d86d86',
+  salt: process.env.SALT || 'e0ce3430c2be00ebe84a98cbc6d67efb6e8a67d331b4c8ad4ea8a3f84bf24e1f'
 };
 
 const config = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,7 @@ import express from 'express';
 import validator from './validator';
 import {TestController, TestEntryController, TestSuccessRouter} from './controllers/testController';
 import {ProfileController} from './controllers/profileController';
-import {AuthMagicLinkController, RefreshTokenController} from './controllers/authController';
+import {AuthMagicLinkController, authPasswordRouter, RefreshTokenController} from './controllers/authController';
 import {EmailMagicLinkSenderController, EmailInviteLinkSenderController, RemoveOldTokensController} from './controllers/emailSenderController';
 import {UploadImageController} from './controllers/uploadImageController';
 import {FriendEntryController} from './controllers/friendController';
@@ -33,7 +33,7 @@ import { errorHandler, notFoundHandler } from './errorHandler';
 import {accessTokenHandler} from './accessTokenHandler';
 import requestIdHandler from './requestId';
 import cors from 'cors';
-import {UserController, UsersController, AddUsersForTest, DelUsersForTest, addFakeUsers, getUsersCount, printSomeUsers, addUser, activateUser, banUser, existUsers} from './controllers/usersController';
+import {UserController, UsersController, AddUsersForTest, DelUsersForTest, addFakeUsers, getUsersCount, printSomeUsers, addUser, activateUser, banUser, existUsers, userSetPassword} from './controllers/usersController';
 import {InvalidateSearchIndexController, InvalidateSearchIndexForTest, SearchController} from './search';
 import { addEvent, delEvent, editEvent, getEvent, getJoinedUsers, joinEvent, unjoinEvent, searchEvents } from './controllers/eventController';
 
@@ -62,6 +62,7 @@ register(app, '/test/success', TestSuccessRouter);
 register(app, '/v1/auth/magicLink', AuthMagicLinkController);
 register(app, '/v1/auth/refresh', RefreshTokenController);
 register(app, '/v1/email/sendMagicLink', EmailMagicLinkSenderController);
+register(app, '/v1/auth/getRefreshTokenByPassword', authPasswordRouter);
 
 if (config.enableMethodsForTest) {
   register(app, '/v1/admin/addUsersForTest', AddUsersForTest, false);
@@ -76,6 +77,7 @@ register(app, '/v1/email/sendInviteLink', EmailInviteLinkSenderController, true)
 // Profiles end-points
 register(app, '/v1/user/friend/:friendId', FriendEntryController, true);
 register(app, '/v1/users/:id', UsersController, true);
+register(app, '/v1/user/setPassword', userSetPassword, true);
 register(app, '/v1/user', UserController, true);
 register(app, '/v1/profile/uploadImage', UploadImageController, true);
 register(app, '/v1/profile/search/', ProfileController, true);

--- a/src/schema/api.json
+++ b/src/schema/api.json
@@ -122,6 +122,15 @@
       "required": [ "email" ]
     },
     {
+      "$id": "#POST>/v1/auth/getRefreshTokenByPassword",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "email": { "type": "string", "format": "email" },
+        "password": { "type": "string" }
+      },
+      "required": [ "email", "password" ]
+    },
+    {
       "$id": "#POST>/v1/email/sendMagicLink",
       "allOf": [{ "$ref": "#RequestBase" }],
       "properties": {
@@ -225,6 +234,14 @@
           }
       },
       "required":["about","fullName"]
+    },
+    {
+      "$id": "#POST>/v1/user/setPassword",
+      "allOf": [{ "$ref": "#RequestBase" }],
+      "properties": {
+        "password": { "type": "string", "maxLength": 128, "minLength": 6 }
+      },
+      "required":["password"]
     },
     {
       "$id": "#POST>/v1/search",


### PR DESCRIPTION
- POST>/v1/user/setPassword - sets user password to the one passed in
  the request, the minimum length is 6, max length is 128.
  authorization is required for this method to be called.
- POST>/v1/auth/getRefreshTokenByPassword - returns a refreshToken and
  accessToken in the same format as /v1/auth/refresh, the request
  should contain email and password.

See the added test case for the usage example.

The high level idea:
- the authorization by email is the primary authorization mechanism,
- as soon as user login - they have an option to set a password,
- after password can be used for authorization.

The potential UI solution:
- on the enter email screen - add a link to login by password, it
  loads a screen with email and password - user can authorize through
  this form,
- on the edit profile page - add an input field to set a password, check
  that input is at least 6 symbols, make this input auto suggestable by
  browsers.